### PR TITLE
Add focused state to text field

### DIFF
--- a/src/data/coreComponents.js
+++ b/src/data/coreComponents.js
@@ -340,6 +340,9 @@ export default {
           id: "cc-text-field-error",
         },
         {
+          id: "cc-text-field-focused",
+        },
+        {
           id: "cc-text-field-autocomplete",
         },
         {

--- a/src/translations/cz/coreComponents.js
+++ b/src/translations/cz/coreComponents.js
@@ -377,6 +377,11 @@ export default {
           description:
             "The error state is used for form validation errors when the error is related to the text field only. Always use a text error along with changing the colour of the field.",
         },
+        "cc-text-field-focused": {
+          title: "Focused state",
+          description:
+            "The focused state should highlight the text field when users start to interact with it. There is always only one focused field in the form.",
+        },
         "cc-text-field-autocomplete": {
           title: "Autocomplete",
           description:

--- a/src/translations/en/coreComponents.js
+++ b/src/translations/en/coreComponents.js
@@ -377,6 +377,11 @@ export default {
           description:
             "The error state is used for form validation errors when the error is related to the text field only. Always use a text error along with changing the colour of the field.",
         },
+        "cc-text-field-focused": {
+          title: "Focused state",
+          description:
+            "The focused state should highlight the text field when users start to interact with it. There is always only one focused field in the form.",
+        },
         "cc-text-field-autocomplete": {
           title: "Autocomplete",
           description:


### PR DESCRIPTION
Hey guys!
I thought that maybe it would be nice to have a focused state in the text field checklist :)

MUI States: https://material.io/design/interaction/states.html#focus
MDN docs: https://developer.mozilla.org/en-US/docs/Web/CSS/:focus
