### PR TITLE
V2 Portuguese

### DIFF
--- a/src/translations/en/components.js
+++ b/src/translations/en/components.js
@@ -869,7 +869,7 @@ export default {
             "When used to take the entire width of the parent container, tab triggers can be stretched to take equal horizontal space.",
         },
         "c-tabs-a11y-keyboard": {
-          title: "Keyboard suppoort",
+          title: "Keyboard support",
           description:
             "When interacting with tabs using the keyboard, they should support arrow navigation to switch between the previous and next panels. The Home and End buttons should also move the selection to the first and last panels, respectively.",
         },

--- a/src/translations/en/maintenance.js
+++ b/src/translations/en/maintenance.js
@@ -173,7 +173,7 @@ export default {
             "Prepare a standard template for initiating the work on a new feature. This template should ensure that proposed changes will be applied across all platforms and won’t break the existing component usage in the product.",
         },
         "m-contribution-engagement": {
-          title: "Engagment",
+          title: "Engagement",
           description:
             "Make sure to highlight and reward contributors' work when making announcements about the new features and help them get support from their managers when they contribute. ",
         },

--- a/src/translations/pt/components.js
+++ b/src/translations/pt/components.js
@@ -1,1037 +1,1044 @@
 export default {
-  title: "Core components",
+  title: "Componentes principais",
   description:
-    "Components are the main building blocks for user interfaces. Building a reusable component library enhances your product development workflow by reducing design and tech debt and speeding up the process. Core components can’t be broken down into granular pieces without losing their meaning.",
+    "Os componentes são os principais elementos de construção das interfaces de usuário. Criar uma biblioteca de componentes reutilizáveis aprimora o fluxo de trabalho de desenvolvimento do seu produto, reduzindo a dívida de design e tecnologia e acelerando o processo. Os componentes centrais não podem ser decompostos em partes menores sem perder seu significado.",
   sections: {
     "c-accordion": {
       title: "Accordion",
       description:
-        "Accordion toggles the visibility of content regions when the trigger element gets pressed.",
+        "O Accordion alterna a visibilidade das regiões de conteúdo quando o elemento de acionamento é pressionado.",
       checklist: {
         "c-accordion-active": {
-          title: "Active state",
+          title: "Estado ativo",
           description:
-            "Accordion comes in two states for toggling its content visibility. If an accordion trigger displays an icon, it should be visually distinct between states.",
+            "O Accordion possui dois estados para alternar a visibilidade do seu conteúdo. Se um acionador de accordion exibe um ícone, ele deve ser visualmente distinto entre os estados.",
         },
         "c-accordion-composition": {
-          title: "Composition",
+          title: "Composição",
           description:
-            "Content area should be flexible enough to support various types of content, including other components.",
+            "A área de conteúdo deve ser flexível o suficiente para suportar vários tipos de conteúdo, incluindo outros componentes.",
         },
         "c-accordion-transition": {
-          title: "Toggle transition",
+          title: "Transição de alternância",
           description:
-            "Add a subtle animation to help users understand and follow the component behavior when switching between states.",
+            "Adicione uma animação sutil para ajudar os usuários a compreender e acompanhar o comportamento do componente ao alternar entre os estados.",
         },
         "c-accordion-a11y-relation": {
-          title: "Content and trigger relation",
+          title: "Relação entre o conteúdo e o acionador",
           description:
-            "Focusing the content area with assistive technologies should announce additional context from the trigger element.",
+            "Quando a área de conteúdo recebe foco por meio de tecnologias assistivas, ela deve anunciar um contexto adicional do elemento de acionamento.",
         },
       },
     },
     "c-alert": {
-      title: "Alert",
+      title: "Alerta",
       description:
-        "Alert displays a prominent message about the whole page or its specific area.",
+        "Os alertas exibem uma mensagem proeminente sobre toda a página ou uma área específica dela.",
       checklist: {
         "c-alert-colors": {
-          title: "Colors",
+          title: "Cores",
           description:
-            "It's crucial to differentiate the alert's visual appearance based on its role. If you're using background colors for role differentiation, ensure there's enough contrast ratio with the content displayed inside the alert.",
+            "É fundamental diferenciar a aparência visual do alerta com base em sua função. Se estiver utilizando cores de fundo para diferenciá-los, assegure-se de que haja um contraste suficiente em relação ao conteúdo exibido dentro do alerta.",
         },
         "c-alert-title": {
-          title: "Title support",
+          title: "Suporte a titulo",
           description:
-            "Supporting a title can help your user understand the context of the message faster for longer alert messages.",
+            "Oferecer suporte à título pode ajudar o usuário a compreender o contexto da mensagem mais rapidamente, especialmente em casos de mensagens de alerta mais longas.",
         },
         "c-alert-icon": {
-          title: "Icon support",
+          title: "Suporte a ícones",
           description:
-            "Icon illustrates the role of the alert and provides an additional hint about it for colorblind people.",
+            "O ícone ilustra o papel do alerta e oferece uma dica adicional para auxiliar pessoas com daltonismo a compreendê-lo.",
         },
         "c-alert-actions": {
-          title: "Supplementary actions",
+          title: "Ações suplementares",
           description:
-            "Actions in the alert should relate to their text and provide a way to react to the message sent to the user.",
+            "As ações nos alertas devem estar relacionadas ao seu texto e proporcionar uma forma de reagir à mensagem enviada ao usuário.",
         },
         "c-alert-responsive": {
-          title: "Responsiveness",
+          title: "Responsividade",
           description:
-            "Alert can adapt to the viewport size, usually becoming full-width for mobile to save some space.",
+            "Os alertas podem se ajustar ao tamanho da tela, geralmente ocupando a largura total em dispositivos móveis para economizar espaço.",
         },
         "c-alert-a11y-roles": {
-          title: "Accessibility roles",
+          title: "Role de acessibilidade",
           description:
-            "When using assistive technologies, alerts should announce their accessibility role correctly.",
+            "Ao utilizar tecnologias assistivas, os alertas devem anunciar corretamente sua role de acessibilidade.",
         },
       },
     },
     "c-avatar": {
       title: "Avatar",
       description:
-        "Thumbnail of a user photo, organization, or a visual representation of other types of content.",
+        "Miniatura de uma foto do usuário, organização ou uma representação visual de outros tipos de conteúdo.",
       checklist: {
         "c-avatar-image": {
-          title: "Image",
+          title: "Imagem",
           description:
-            "Avatars should mask an image into their shape and work with any image size since they may get this image from unknown data sources.",
+            "Os avatares devem mascarar uma imagem em sua forma e funcionar com qualquer tamanho de imagem, uma vez que podem obter essa imagem de fontes de dados desconhecidas.",
         },
         "c-avatar-image-fallback": {
-          title: "Image fallback",
+          title: "Recurso alternativo de imagem",
           description:
-            "When not passing an image or there is an image loading error, avatars should be able to show a fallback with a different image, icon, or text initials.",
+            "Quando não for fornecida uma imagem ou ocorrer um erro ao carregar a imagem, os avatares devem ser capazes de exibir um recurso alternativo com uma imagem, ícone ou iniciais de texto diferentes.",
         },
         "c-avatar-sizes": {
-          title: "Sizes",
+          title: "Tamanhos",
           description:
-            "There are many contexts to use an avatar, which require different sizes for the component. Use at least 2-3 different sizes for average projects and ensure there’s at least a small size available.",
+            "Há vários contextos nos quais é necessário utilizar um avatar, exigindo diferentes tamanhos para o componente. Em projetos comuns, é recomendado utilizar pelo menos 2-3 tamanhos distintos e garantir que haja pelo menos um tamanho pequeno disponível.",
         },
         "c-avatar-colors": {
-          title: "Colors",
+          title: "Cores",
           description:
-            "A background color should be applied to the avatar shape when used without an image. Make sure that icons and text have enough contrast ratio with the background according to the WCAG AA standard.",
+            "Quando utilizado sem uma imagem, o avatar deve ter uma cor de fundo aplicada à sua forma. Certifique-se de que os ícones e o texto possuam um contraste adequado em relação ao fundo, seguindo o padrão WCAG AA.",
         },
         "c-avatar-shape": {
-          title: "Shape",
+          title: "Formas",
           description:
-            "Avatars might support multiple shapes, like square or circle, based on the area they are used in.",
+            "Os avatares podem ter suporte a múltiplas formas, como quadrado ou círculo, dependendo da área em que são utilizados.",
         },
         "c-avatar-group": {
-          title: "Avatar groups",
+          title: "Grupos de avatares",
           description:
-            "Multiple avatars can be stacked together to represent a group of users.",
+            "Múltiplos avatares podem ser empilhados juntos para representar um grupo de usuários.",
         },
         "c-avatar-a11y-label": {
-          title: "Accessibility label",
+          title: "Label de acessibilidade",
           description:
-            "Avatar should provide an accessibility label when used for non-decorative images and has no text representation of its contents.",
+            "O avatar deve fornecer uma label acessível quando utilizado para imagens não decorativas e não possui uma representação textual de seus conteúdos.",
         },
       },
     },
     "c-badge": {
       title: "Badge",
       description:
-        "Compact element that represents the status of an object or user input.",
+        "Elemento compacto que representa o status de um objeto ou entrada do usuário.",
       checklist: {
         "c-badge-colors": {
-          title: "Colors",
+          title: "Cores",
           description:
-            "Badges may play various roles in your product, and having a predefined color for each role should help users understand their meaning. When changing colors, make sure the text has enough contrast ratio with the background according to the WCAG AA standard.",
+            "Os badges podem desempenhar várias funções em seu produto, e ter uma cor pré-definida para cada função deve ajudar os usuários a entender seu significado. Ao alterar as cores, certifique-se de que o texto tenha uma proporção de contraste adequada com o fundo, de acordo com o padrão WCAG AA.",
         },
         "c-badge-variants": {
-          title: "Variants",
+          title: "Variantes",
           description:
-            "Based on where in the product badges are rendered, you might support multiple component variants. For example, you can have some badges using a faded background to avoid drawing too much attention.",
+            "Com base no local em que os badges são exibidos no produto, é possível oferecer várias variantes do componente. Por exemplo, é possível ter alguns badges com um fundo desbotado para evitar chamar muita atenção.",
         },
         "c-badge-sizes": {
-          title: "Sizes",
+          title: "Tamanhos",
           description:
-            "Badges can come in multiple sizes depending on where a badge is used. For example, you can use the large size for marketing pages.",
+            "Os badges podem ser apresentados em vários tamanhos, dependendo de onde são utilizados. Por exemplo, você pode usar o tamanho grande em páginas de marketing.",
         },
         "c-badge-icon-support": {
-          title: "Icon support",
+          title: "Suporte a ícones",
           description:
-            "To better illustrate the meaning of a badge, you can display an icon next to the text. Make sure that for small badges, icon contents are still recognizable.",
+            "Para ilustrar melhor o significado de um badge, você pode exibir um ícone ao lado do texto. Certifique-se de que, para badges pequenos, o conteúdo do ícone ainda seja reconhecível.",
         },
         "c-badge-dismiss": {
-          title: "Dismissible action",
+          title: "Ação de descarte",
           description:
-            "Badges can be used as a dynamic way to display selected values, and there should be a way to dismiss them.",
+            "Os badges podem ser usados como uma forma dinâmica de exibir valores selecionados, e deve haver uma maneira de descartá-los.",
         },
         "c-badge-empty": {
-          title: "Empty state",
+          title: "Estado vazio",
           description:
-            "Badges can be used without any text content inside. That usually requires changing their styles to preserve the correct shape.",
+            "Os distintivos podem ser utilizados sem nenhum conteúdo de texto interno. Isso geralmente requer a alteração de seus estilos para preservar a forma correta.",
         },
         "c-badge-positioning": {
-          title: "Positioning",
+          title: "Posicionamento",
           description:
-            "When used as a status badge, like a notification indicator – you should be able to position it relative to those elements.",
+            "Quando usado como um distintivo de status, como um indicador de notificação, você deve ser capaz de posicioná-lo em relação a esses elementos.",
         },
       },
     },
     "c-button": {
-      title: "Button",
-      description: "Interactive element used for single-step actions.",
+      title: "Botão",
+      description:
+        "Elemento interativo utilizado para ações de um único passo.",
       checklist: {
         "c-button-colors": {
-          title: "Colors",
+          title: "Cores",
           description:
-            "Buttons may play various roles in your product, and having a predefined color for each role should help users understand their meaning. When changing colors, make sure the text has enough contrast ratio with the background according to the WCAG AA standard.",
+            "Botões podem desempenhar diferentes papéis em seu produto, e ter uma cor pré-definida para cada papel deve ajudar os usuários a entender seu significado. Ao alterar as cores, certifique-se de que o texto tenha uma proporção de contraste adequada com o fundo, de acordo com o padrão WCAG AA.",
         },
         "c-button-variants": {
-          title: "Variants",
+          title: "Variantes",
           description:
-            "When using multiple buttons, there should be a way to differentiate between primary and secondary actions. Buttons may play different roles for the user or be used on various surfaces, and they have to change how they look.",
+            "Ao utilizar múltiplos botões, deve haver uma forma de diferenciar entre ações primárias e secundárias. Os botões podem desempenhar diferentes papéis para o usuário ou serem utilizados em diferentes superfícies, e é necessário que eles alterem sua aparência de acordo.",
         },
         "c-button-sizes": {
-          title: "Sizes",
+          title: "Tamanhos",
           description:
-            "Depending on where a button will be used, it can come in multiple sizes. For example, you can use the small size for dense areas of your application.",
+            "Dependendo de onde um botão será usado, ele pode ter vários tamanhos. Por exemplo, você pode usar o tamanho pequeno para áreas densas da sua aplicação.",
         },
         "c-button-icon": {
-          title: "Icon support",
+          title: "Suporte a ícones",
           description:
-            "Icons easily communicate the button's purpose when used next to its label or can be used without text when there's insufficient space. Ensure the accessibility label is provided when used with an icon only.",
+            "Ícones comunicam facilmente o propósito do botão quando utilizados ao lado de uma label ou podem ser usados sem texto quando há pouco espaço disponível. Certifique-se de fornecer uma label acessível quando utilizar apenas o ícone.",
         },
         "c-button-hover": {
-          title: "Hover state",
+          title: "Estado de hover",
           description:
-            "Clearly show that the button is interactive when hovered with a mouse cursor.",
+            "Mostre claramente que o botão é interativo quando o cursor do mouse estiver sobre ele.",
         },
         "c-button-active": {
-          title: "Active state",
+          title: "Estado ativo",
           description:
-            "Provide a visual cue when a button is pressed, used for selecting a value, or toggles other elements on the page.",
+            "Forneça uma indicação visual quando um botão for pressionado, usado para selecionar um valor ou alternar outros elementos na página.",
         },
         "c-button-loading": {
-          title: "Loading state",
+          title: "Estado de carregamento",
           description:
-            "Indicate when users have to wait for the result of their action after pressing a button. If a spinner is used to display this state, ensure it’s not changing the original button width or height.",
+            "Indique quando os usuários devem esperar pelo resultado de sua ação após pressionar um botão. Se um indicador de progresso (spinner) for usado para exibir esse estado, certifique-se de que ele não altere a largura ou altura original do botão.",
         },
         "c-button-disabled": {
-          title: "Disabled state",
+          title: "Estado desabilitado",
           description:
-            "Visually shows that the button is not interactive and restricts it from being pressed.",
+            "Mostre visualmente que o botão não é interativo e impeça que ele seja pressionado.",
         },
         "c-button-a11y-role": {
-          title: "Accessibility role",
+          title: "Role de acessibilidade",
           description:
-            "Button should correctly announce the button or link accessibility roles and automatically resolve it based on the properties passed to it.",
+            "O botão deve anunciar corretamente as roles de acessibilidade do botão ou do link e resolvê-los automaticamente com base nas propriedades passadas para ele.",
         },
         "c-button-a11y-focus": {
-          title: "Focus indicator",
+          title: "Indicador de foco",
           description:
-            "Button should have a visible focus indicator when it’s focused using the keyboard or assistive technologies.",
+            "O botão deve ter um indicador de foco visível quando estiver em foco utilizando o teclado ou tecnologias assistivas.",
         },
       },
     },
     "c-breadcrumbs": {
       title: "Breadcrumbs",
       description:
-        "Top-level product navigation that helps user understand the location of the current page and navigate back to its parents.",
+        "Navegação principal do produto que ajuda o usuário a compreender a localização da página atual e navegar de volta aos seus respectivos níveis superiores.",
       checklist: {
         "c-breadcrumbs-icon": {
-          title: "Icon support",
+          title: "Suporte a ícones",
           description:
-            "Icons help to communicate the roles of the pages to which breadcrumbs items link. Most of the time, you want to ensure they’re used consistently, not only for random items in the list.",
+            "Ícones ajudam a comunicar os papéis das páginas às quais os itens do menu de navegação apontam. Na maioria das vezes, é importante garantir que sejam usados de forma consistente, não apenas para itens aleatórios na lista.",
         },
         "c-breadcrumbs-disabled": {
-          title: "Disabled state",
+          title: "Estado desabilitado",
           description:
-            "Each item in the list can be disabled separately to prevent users from navigating to the page.",
+            "Cada item da lista pode ser desabilitado individualmente para impedir que os usuários naveguem para a página.",
         },
         "c-breadcrumbs-collapsed": {
-          title: "Collapsed state",
+          title: "Estado colapsado",
           description:
-            "If breadcrumbs items don’t fit into the parent container, the list should support collapsing items only to keep the relevant ones visible to the user.",
+            "Se os itens do menu de navegação não couberem no contêiner pai, a lista deve oferecer suporte ao colapso de itens apenas para manter visíveis aqueles relevantes para o usuário.",
         },
         "c-breadcrumbs-separator": {
-          title: "Custom separator",
+          title: "Separador personalizado",
           description:
-            "Depending on the usage context, items in the breadcrumbs list can use different separator styles.",
+            "Dependendo do contexto de uso, os itens na lista de breadcrumbs podem utilizar diferentes estilos de separadores.",
         },
       },
     },
     "c-calendar": {
-      title: "Calendar",
+      title: "Calendário",
       description:
-        "Grid displaying days in one or more months and allow users to select a single date or a date range",
+        "Grid que exibe os dias de um ou mais meses e permite que os usuários selecionem uma única data ou um intervalo de datas.",
       checklist: {
         "c-calendar-modes": {
-          title: "Display modes",
+          title: "Modos de exibição",
           description:
-            "Calendar might be used in various product areas and viewports. Make sure to support different display modes for rendering more than one month or a vertical layout.",
+            "O calendário pode ser utilizado em diversas áreas e tamanhos de tela do produto. Certifique-se de suportar diferentes modos de exibição para mostrar mais de um mês ou um layout vertical.",
         },
         "c-calendar-selected": {
-          title: "Selected state",
+          title: "Estado selecionado",
           description:
-            "Calendar should support a single date and a selection range. Selected dates should be visually highlighted, and the range between selected dates should be visible to the users.",
+            "O calendário deve suportar a seleção de uma única data e um intervalo de datas. As datas selecionadas devem ser destacadas visualmente, e o intervalo entre as datas selecionadas deve ser visível para os usuários.",
         },
         "c-calendar-month-selection": {
-          title: "Month selection",
+          title: "Seleção de mês",
           description:
-            "To help users navigate longer date ranges, the calendar should provide an easy way to switch displayed months.",
+            "Para ajudar os usuários a navegar por intervalos de datas mais longos, o calendário deve fornecer uma maneira fácil de alternar entre os meses exibidos.",
         },
         "c-calendar-day-names": {
-          title: "Day names",
+          title: "Nomes dos dias",
           description:
-            "Provide short labels for the weekday names in addition to the date numbers to let users easier navigate the date selection.",
+            "Fornecer labels curtas para os nomes dos dias da semana, além dos números das datas, para facilitar a navegação na seleção de datas pelos usuários.",
         },
         "c-calendar-i18n": {
-          title: "Internationalisation",
+          title: "Internacionalização",
           description:
-            "Calendars should be localized for all country regions supported by the product. That includes date formats and correct ordering of the weekdays.",
+            "Os calendários devem ser adaptados para todas as regiões e países suportados pelo produto. Isso inclui formatos de data e a correta ordenação dos dias da semana, de acordo com as convenções locais.",
         },
         "c-calendar-a11y-keyboard": {
-          title: "Keyboard navigation",
+          title: "Navegação por teclado",
           description:
-            "Calendar dates should be focusable with keyboard and assistive technologies. Further navigation on the dates should happen with keyboard arrows or screen reader navigation and support switching the month by navigating out of a column or a row.",
+            "As datas do calendário devem ser acessíveis pelo teclado e por tecnologias assistivas. A navegação nas datas pode ser feita usando as setas do teclado ou as opções de navegação do leitor de tela. Além disso, é importante permitir a troca de mês ao navegar para fora de uma coluna ou linha.",
         },
         "c-calendar-a11y-state": {
-          title: "State announcement",
+          title: "Anúncio de estado",
           description:
-            "Selected dates should be announced by the assistive technologies when they get focused.",
+            "As datas selecionadas devem ser anunciadas pelas tecnologias assistivas quando recebem foco.",
         },
       },
     },
     "c-card": {
       title: "Card",
       description:
-        "Container to group information about subjects and their related actions.",
+        "Container para agrupar informações sobre assuntos e suas ações relacionadas.",
+
       checklist: {
         "c-card-composition": {
-          title: "Content composition",
+          title: "Composição de conteúdo",
           description:
-            "Content area should be flexible enough to support various types of content, including other components.",
+            "A área de conteúdo deve ser flexível o suficiente para suportar vários tipos de conteúdo, incluindo outros componentes.",
         },
         "c-card-media-sections": {
-          title: "Media sections",
+          title: "Seções de mídia",
           description:
-            "Cards are frequently used with media content. The most popular options are having a full-width area on top of the content or an area at one of the card’s sides.",
+            "Os cards são frequentemente utilizados em conjunto com conteúdo de mídia. As opções mais populares são ter uma área de largura total acima do conteúdo ou uma área em um dos lados do card.",
         },
         "c-card-actions": {
-          title: "Supplementary actions",
+          title: "Ações suplementares",
           description:
-            "Cards can be used with actions usually placed at the bottom of the card, or the card itself can be tappable and represent an action.",
+            "Os cards podem ser utilizados com ações geralmente posicionadas na parte inferior do card, ou o próprio card pode ser clicável, representando uma ação.",
         },
         "c-card-responsive": {
-          title: "Responsiveness",
+          title: "Responsividade",
           description:
-            "On mobile viewports, cards are usually full-width to save space for the content.",
+            "Nos dispositivos móveis, os cards geralmente ocupam toda a largura da tela para economizar espaço para o conteúdo.",
         },
         "c-card-groups": {
-          title: "Card groups",
+          title: "Grupos de cards",
           description:
-            "Multiple cards can be grouped in a single list of content sections.",
+            "Vários cards podem ser agrupados em uma única lista de seções de conteúdo.",
         },
       },
     },
     "c-carousel": {
-      title: "Carousel",
+      title: "Carrossel",
       description:
-        "Horizontal scrollable areas used for displaying grouped content.",
+        "Áreas com rolagem horizontal usadas para exibir conteúdo agrupado.",
       checklist: {
         "c-carousel-navigation": {
-          title: "Navigation controls",
+          title: "Controles de navegação",
           description:
-            "Carousels should be accessible for navigating its content on devices that work with the mouse instead of touch events.",
+            "Os carrosséis devem ser acessíveis para navegar seu conteúdo em dispositivos que utilizam o mouse em vez de eventos de toque.",
         },
         "c-carousel-composition": {
-          title: "Item composition",
+          title: "Composição de itens",
           description:
-            "Content area of the carousel items should be flexible enough to support various types of content, including other components.",
+            "A área de conteúdo dos itens do carrossel deve ser flexível o suficiente para suportar vários tipos de conteúdo, incluindo outros componentes.",
         },
         "c-carousel-item-size": {
-          title: "Item sizes",
+          title: "Tamanhos dos itens",
           description:
-            "Layout of the items should be flexible to support different types of content. For mobile devices, make sure to show a part of the carousel item that doesn’t fit into the viewport to indicate the scrollable area.",
+            "O layout dos itens deve ser flexível para suportar diferentes tipos de conteúdo. Para dispositivos móveis, certifique-se de mostrar uma parte do item do carrossel que não cabe na tela para indicar a área rolável.",
         },
         "c-carousel-touch": {
-          title: "Touch navigation",
+          title: "Navegação por toque",
           description:
-            "Carousel content should be rendered inside a scrollable area to support touch events.",
+            "O conteúdo do carrossel deve ser renderizado dentro de uma área rolável para suportar eventos de toque.",
         },
         "c-carousel-responsive": {
-          title: "Responsiveness",
+          title: "Responsividade",
           description:
-            "Carousel items layout might require adjustments based on the available space.",
+            "O layout dos itens do carrossel pode exigir ajustes com base no espaço disponível.",
         },
         "c-carousel-a11y-keyboard-navigation": {
-          title: "Keyboard navigation",
+          title: "Navegação por teclado",
           description:
-            "Keyboard and assistive technologies users should be able to navigate the carousel content without clicking on the navigation controls.",
+            "Usuários de teclado e tecnologias assistivas devem ser capazes de navegar pelo conteúdo do carrossel sem depender dos controles de navegação por clique.",
         },
       },
     },
     "c-checkbox": {
       title: "Checkbox",
       description:
-        "Form field used to select one or multiple values from the list.",
+        "Campo de formulário usado para selecionar um ou vários valores da lista.",
       checklist: {
         "c-checkbox-label": {
           title: "Label",
           description:
-            "There should be a text label linked with the checkbox field. Clicking the label should also trigger the checkbox selection. If the label is not rendered on the page, assistive technologies should still announce it.",
+            "Deve haver uma label de texto vinculada ao campo de checkbox. Clicar no rótulo também deve acionar a seleção do checkbox. Se o rótulo não for exibido na página, as tecnologias assistivas ainda devem anunciá-lo.",
         },
         "c-checkbox-checked": {
-          title: "Checked state",
+          title: "Estado selecionado",
           description:
-            "Display when the checkbox gets selected and is used for the form submission.",
+            "Exiba quando o checkbox for selecionado e utilizado para a submissão do formulário.",
         },
         "c-checkbox-error": {
-          title: "Error state",
+          title: "Estado de erro",
           description:
-            "Use an error state for form validation when the error is related to the checkbox field. Always use a text error along with a different field color.",
+            "Utilize um estado de erro para a validação do formulário quando o erro estiver relacionado ao campo de checkbox. Sempre utilize um texto de erro juntamente com uma cor de campo diferente.",
         },
         "c-checkbox-disabled": {
-          title: "Disabled state",
+          title: "Estado desabilitado",
           description:
-            "Use a disabled state to prevent checkbox interactions and remove its value from the submitted form values.",
+            "Utilize um estado desabilitado para impedir interações com o checkbox e remover o seu valor dos valores enviados pelo formulário.",
         },
         "c-checkbox-indeterminate": {
-          title: "Indeterminate state",
+          title: "Estado indeterminado",
           description:
-            "Visually display when the checkbox has children selectable elements and only some are selected.",
+            "Visualmente, indique quando a checkbox possui elementos filhos selecionáveis e somente alguns estão selecionados.",
         },
         "c-checkbox-group": {
-          title: "Checkbox group",
+          title: "Grupo de checkboxes",
           description:
-            "Checkboxes can be grouped to work with multiple values at the same time.",
+            "Os checkboxes podem ser agrupados para trabalhar com múltiplos valores ao mesmo tempo.",
         },
         "c-checkbox-a11y-keyboard": {
-          title: "Keyboard support",
+          title: "Suporte ao teclado",
           description:
-            "Checkbox selections should be triggered with the keyboard. Using native elements for this should provide this kind of interaction automatically.",
+            "As seleções dos checkboxes devem ser acionados com o teclado. Usar elementos nativos para isso deve fornecer esse tipo de interação automaticamente.",
         },
       },
     },
     "c-divider": {
-      title: "Divider",
-      description: "Element for visual content separation",
+      title: "Divisor",
+      description: "Elemento para separação visual de conteúdo",
       checklist: {
         "c-divider-direction": {
-          title: "Direction",
+          title: "Direção",
           description:
-            "Dividers should separate both horizontal and vertical lists of content.",
+            "Divisores devem separar tanto listas de conteúdo horizontal quanto vertical.",
         },
         "c-divider-a11y-role": {
-          title: "Accessibility role",
+          title: "Role de acessibilidade",
           description:
-            "If the divider is playing a non-decorative role in the layout, its role should be announced by the assistive technologies.",
+            "Se o divisor desempenha um papel funcional no layout, além do papel decorativo, seu papel deve ser anunciado pelas tecnologias assistivas.",
         },
       },
     },
     "c-dropdown": {
       title: "Dropdown",
-      description: "List of contextual actions that users can trigger.",
+      description: "Lista de ações contextuais que os usuários podem acionar.",
       checklist: {
         "c-dropdown-composition": {
-          title: "Content composition",
+          title: "Composição de conteúdo",
           description:
-            "Dropdowns may be used for context menus, product navigation, and other purposes. Their content area should be flexible enough to support various types of content, including other components.",
+            "Dropdowns podem ser usados para menus contextuais, navegação de produtos e outros fins. A área de conteúdo deles deve ser flexível o suficiente para suportar vários tipos de conteúdo, incluindo outros componentes.",
         },
         "c-dropdown-hover": {
-          title: "Hover trigger",
+          title: "Acionamento por hover",
           description:
-            "Dropdown should support displaying its content on hover events. The same behavior should happen for keyboard users once its trigger gets focused.",
+            "O dropdown deve suportar a exibição do seu conteúdo em eventos de hover. O mesmo comportamento deve ocorrer para usuários de teclado quando o seu acionador recebe foco.",
         },
         "c-dropdown-positioning": {
-          title: "Dynamic positioning",
+          title: "Posicionamento dinâmico",
           description:
-            "Dropdown content should be displayed based on the current position of the trigger element on the screen and always stay visible to the user.",
+            "O conteúdo do dropdown deve ser exibido com base na posição atual do elemento de gatilho na tela e sempre permanecer visível para o usuário.",
         },
         "c-dropdown-responsive": {
-          title: "Responsiveness",
+          title: "Responsividade",
           description:
-            "Dropdown content should be adjusted if it doesn’t fit the screen the same way on mobile devices as on desktop.",
+            "O conteúdo do dropdown deve ser ajustado se não couber na tela da mesma forma em dispositivos móveis como em desktop.",
         },
         "c-dropdown-a11y-focus": {
-          title: "Focus trapping",
+          title: "Captura de foco",
           description:
-            "Once dropdown content is opened, the focus ring should move inside its content area and return to the trigger element when closed.",
+            "Quando o conteúdo do dropdown é aberto, o foco deve ser movido para dentro da área de conteúdo e retornar ao elemento acionador quando fechado.",
         },
         "c-dropdown-a11y-keyboard": {
-          title: "Keyboard navigation",
+          title: "Suporte ao teclado",
           description:
-            "Dropdown should be accessible for keyboard and assistive technologies. Users should be able to close the dropdown using a separate close action, or once they tab outside the content area.",
+            "O dropdown deve ser acessível para teclado e tecnologias assistivas. Os usuários devem ser capazes de fechar o dropdown usando uma ação separada de fechamento ou ao pressionar uma área fora do conteúdo do dropdown.",
         },
       },
     },
     "c-icon": {
-      title: "Icon",
-      description: "Wrapper for SVG assets to control their appearance",
+      title: "Ícone",
+      description:
+        "Wrapper para elementos SVG para controlar sua apresentação visual",
       checklist: {
         "c-icon-colors": {
-          title: "Colors",
+          title: "Cores",
           description:
-            "Icons should support color values available in design system tokens. Additionally, it’s a good practice to support color inheritance from their parent element.",
+            "Os ícones devem suportar os valores de cor disponíveis nos tokens do design system. Além disso, é uma boa prática permitir a herança de cor a partir do elemento pai.",
         },
         "c-icon-sizes": {
-          title: "Sizes",
+          title: "Tamanhos",
           description:
-            "Icons should have several predefined sizes to provide a holistic experience across the product. Typography pairings may be used for these size values to ensure they align with the text sizes.",
+            "Os ícones devem possuir diversos tamanhos pré-definidos para oferecer uma experiência completa em todo o produto. É recomendável utilizar combinações tipográficas para esses valores de tamanho, assegurando que estejam alinhados com os tamanhos do texto.",
         },
         "c-icon-a11y-decoration": {
-          title: "Interactivity",
+          title: "Interatividade",
           description:
-            "Icons are used as decorative elements most of the time. If an icon is meant to be interactive – that functionality should be included using buttons, links, or other interactive components.",
+            "A maioria das vezes, os ícones são usados como elementos decorativos. Se um ícone tiver a intenção de ser interativo, essa funcionalidade deve ser incluída usando botões, links ou outros componentes interativos.",
         },
       },
     },
     "c-image": {
-      title: "Image",
+      title: "Imagem",
       description:
-        "Utility for displaying images and controlling their behavior.",
+        "Utilitário para exibir imagens e controlar o seu comportamento.",
       checklist: {
         "c-image-sizes": {
-          title: "Sizes",
+          title: "Tamanhos",
           description:
-            "Image should be flexible in terms of supported sizes. Besides just supporting width and height – add support for aspect ratio to scale its proportions based on the parent element dynamically.",
+            "A imagem deve ser flexível em termos de tamanhos suportados. Além de suportar apenas largura e altura, adicione suporte para proporção de aspecto para dimensionar suas proporções com base no elemento pai de forma dinâmica.",
         },
         "c-image-fallback": {
-          title: "Image fallback",
+          title: "Recurso alternativo de imagem",
           description:
-            "Display a fallback when the image URL is incorrect or undefined. That can be an empty box with a background, an icon, or a static placeholder image.",
+            "Exiba um recurso alternativo quando a URL da imagem estiver incorreta ou indefinida. Isso pode ser uma caixa vazia com um fundo, um ícone ou uma imagem estática de substituição.",
         },
         "c-image-density": {
-          title: "Screen density support",
+          title: "Suporte à densidade de tela",
           description:
-            "Depending on the screen density, you should support loading multiple image assets of different sizes and serve the relevant one to the user.",
+            "Para atender à densidade de tela, é recomendado suportar o carregamento de múltiplos recursos de imagem em tamanhos diferentes e servir o mais adequado ao usuário.",
         },
         "c-image-a11y-alt": {
-          title: "Alt text",
+          title: "Texto alternativo",
           description:
-            "When the image is non-decorative, it should provide an alt text describing the picture contents.",
+            "Quando a imagem não for apenas decorativa, é importante fornecer um texto alternativo (alt text) descrevendo o conteúdo da imagem.",
         },
       },
     },
     "c-link": {
       title: "Link",
       description:
-        "Interactive text element used for navigation within the text paragraphs.",
+        "Elemento de texto interativo usado para navegação dentro dos parágrafos de texto.",
       checklist: {
         "c-link-icon": {
-          title: "Icon support",
+          title: "Suporte a ícones",
           description:
-            "An icon can be used next to the link to communicate the purpose of the link. Icons shouldn’t be used inside a link without a text label.",
+            "Um ícone pode ser usado ao lado do link para comunicar o propósito do link. Ícones não devem ser usados dentro de um link sem uma label de texto.",
         },
         "c-link-colors": {
-          title: "Colors",
+          title: "Cores",
           description:
-            "Links may play various roles in your product, and having a predefined color for each role should help users understand their meaning. Since the link is a text element, it should be able to automatically inherit the color defined by its parent element, the same as other text content.",
+            "Os links podem desempenhar diversos papéis no seu produto, e ter uma cor pré-definida para cada papel deve ajudar os usuários a entender o seu significado. Como o link é um elemento de texto, ele deve ser capaz de herdar automaticamente a cor definida pelo seu elemento pai, assim como outros conteúdos de texto.",
         },
         "c-link-disabled": {
-          title: "Disabled state",
+          title: "Estado desabilitado",
           description:
-            "Visually shows that the link is not interactive and restricts it from being pressed.",
+            "Indique visualmente que o link não é interativo e impeça que seja pressionado.",
         },
         "c-link-font-inheritance": {
-          title: "Font inheritance",
+          title: "Herança de fonte",
           description:
-            "Links should be able to inherit the typography styles when used as a part of the text element.",
+            "Os links devem ser capazes de herdar os estilos tipográficos quando usados como parte do elemento de texto.",
         },
         "c-link-multiline": {
-          title: "Multiline display",
+          title: "Exibição de várias linhas",
           description:
-            "When used inside a text paragraph, links should support multiline display without breaking the text flow.",
+            "Quando usados dentro de um parágrafo de texto, os links devem suportar a exibição de várias linhas sem interromper o fluxo do texto.",
         },
         "c-link-a11y-role": {
-          title: "Accessibility role",
+          title: "Role de acessibilidade",
           description:
-            "Links should correctly announce the button or link accessibility roles automatically resolve it based on the properties passed to it.",
+            "Os links devem anunciar corretamente as funções de acessibilidade do botão ou do link, resolvendo-as automaticamente com base nas propriedades passadas para ele.",
         },
       },
     },
     "c-list": {
-      title: "List",
-      description: "List is used to display a list of items.",
+      title: "Lista",
+      description: "A lista é usada para exibir uma lista de itens.",
       checklist: {
         "c-list-order": {
-          title: "Order",
+          title: "Ordem",
           description:
-            "List items can use bulleted, numbered, and other styles and types of ordering.",
+            "Os itens da lista podem utilizar estilos e tipos de ordenação como marcadores, numerados e outros.",
         },
         "c-list-composition": {
-          title: "Content cmposition",
+          title: "Composição de conteúdo",
           description:
-            "List item content areas should be flexible enough to support various types of content, including other components.",
+            "As áreas de conteúdo dos itens da lista devem ser flexíveis o suficiente para suportar vários tipos de conteúdo, incluindo outros componentes.",
         },
         "c-list-a11y-role": {
-          title: "Accessibility role",
+          title: "Role acessível",
           description:
-            "Assistive technologies should announce lists with the correct role and number of items displayed.",
+            "As tecnologias assistivas devem anunciar listas com a role correta e o número de itens exibidos.",
         },
       },
     },
     "c-loading-indicator": {
-      title: "Loading indicator",
+      title: "Indicador de carregamento",
       description:
-        "Animated element that communicates progress without telling how long the process will take.",
+        "Elemento animado que indica o progresso sem informar a duração exata do processo.",
       checklist: {
         "c-loading-indicator-colors": {
-          title: "Colors",
+          title: "Cores",
           description:
-            "Loading indicators might be used inside the elements with various roles and follow their color scheme.",
+            "Os indicadores de carregamento podem ser utilizados em elementos com diferentes funções e devem seguir o esquema de cores correspondente a esses elementos.",
         },
         "c-loading-indicators-sizes": {
-          title: "Sizes",
+          title: "Tamanhos",
           description:
-            "Loading indicators might provide multiple sizes, depending on the size of the areas where the loading indicator is rendered.",
+            "Os indicadores de carregamento podem oferecer diferentes tamanhos, de acordo com o tamanho das áreas em que são exibidos.",
         },
         "c-loading-indicator-time": {
-          title: "Loading duration",
+          title: "Duração do carregamento",
           description:
-            "In some cases, the wait time can’t be determined. The loading indicator should be shown until the loading finishes or an error happens. In other cases, it’s better to indicate the time left until the loading is finished.",
+            "Em alguns casos, o tempo de espera não pode ser determinado. O indicador de carregamento deve ser exibido até que o carregamento seja concluído ou ocorra um erro. Em outros casos, é melhor indicar o tempo restante até que o carregamento seja concluído.",
         },
         "c-loading-indicator-a11y-reduced-motion": {
-          title: "Reduced motion",
+          title: "Animação reduzida",
           description:
-            "The loading indicator should be synced with the system motion settings and reduce its animation speed when reduced motion settings are turned on.",
+            "O indicador de carregamento deve estar sincronizado com as configurações de movimento do sistema e reduzir a velocidade de animação quando as configurações de movimento reduzido estiverem ativadas.",
         },
         "c-loading-indicator-a11y-label": {
-          title: "Accessibility label",
+          title: "Label de acessibilidade",
           description:
-            "If the loading indicator is standalone – provide an accessibility label for the content area it’s loading.",
+            "Se o indicador de carregamento estiver isolado, forneça uma label acessível para a área de conteúdo que está sendo carregada.",
         },
       },
     },
     "c-modal": {
       title: "Modal",
       description:
-        "Container appearing in front of the main content to provide critical information or an actionable piece of content.",
+        "Contêiner que aparece na frente do conteúdo principal para fornecer informações críticas ou um conteúdo acionável.",
       checklist: {
         "c-modal-composition": {
-          title: "Content composition",
+          title: "Composição de conteúdo",
           description:
-            "The main content area should be flexible enough to support various types of content, including other components.",
+            "A área de conteúdo principal deve ser flexível o suficiente para suportar vários tipos de conteúdo, incluindo outros componentes.",
         },
         "c-modal-actions": {
-          title: "Supplementary actions",
+          title: "Ações suplementares",
           description:
-            "Since content in the modal may be actionable, it’s essential to have an area for action elements. This area is usually located at the bottom of the modal container.",
+            "Como o conteúdo no modal pode ser acionável, é essencial ter uma área para elementos de ação. Essa área geralmente está localizada na parte inferior do contêiner modal.",
         },
         "c-modal-close": {
-          title: "Close action",
+          title: "Ação de fechar",
           description:
-            "Modals should provide a straightforward way to close, as they block content when open. This may be either a separate close button or one of the supplementary actions.",
+            "Os modais devem oferecer uma forma direta de fechamento, pois eles bloqueiam o conteúdo quando estão abertos. Isso pode ser feito através de um botão de fechar separado ou como uma das ações complementares disponíveis.",
         },
         "c-modal-positioning": {
-          title: "Positioning",
+          title: "Posicionamento",
           description:
-            "Modals can be positioned in the center of the screen or displayed as sliding sheets on either side of the screen.",
+            "Os modais podem ser posicionados no centro da tela ou exibidos como painéis deslizantes em um dos lados da tela.",
         },
         "c-modal-sizes": {
-          title: "Sizes",
+          title: "Tamanhos",
           description:
-            "Provide support for changing the modal height and width based on the content you display.",
+            "Forneça suporte para alterar a altura e largura do modal com base no conteúdo que você exibe.",
         },
         "c-modal-a11y-focus": {
-          title: "Focus trapping",
+          title: "Captura de foco",
           description:
-            "When the modal gets opened, the user focus should move to the first focusable element and stay trapped inside it. When the modal is closed, the focus should return to the last active element.",
+            "Ao abrir o modal, o foco do usuário deve ser movido para o primeiro elemento com foco e permanecer restrito a ele. Quando o modal for fechado, o foco deve retornar ao último elemento ativo.",
         },
         "c-modal-a11y-keyboard": {
-          title: "Keyboard navigation",
+          title: "Navegação por teclado",
           description:
-            "It should be possible to close a modal by pressing the Esc key, and all the focusable elements inside the modal container should be accessible with keyboard navigation.",
+            "Deve ser possível fechar um modal ao pressionar a tecla Esc, e todos os elementos com foco dentro do contêiner do modal devem ser acessíveis por meio da navegação pelo teclado.",
         },
         "c-modal-a11y-labels": {
-          title: "Title and subtitle labeling",
+          title: "Título e subtítulo",
           description:
-            "Modals should use the correct accessibility role, and they should be labeled by the title and subtitle elements. If there is no visible title or subtitle, it may use an accessibility label instead.",
+            "Os modais devem usar a role de acessibilidade correta e devem ser caracterizados pelos elementos de título e subtítulo. Se não houver título ou subtítulo visível, a modal pode usar uma label acessível.",
         },
       },
     },
     "c-pagination": {
-      title: "Pagination",
-      description: "Pagination enables a selection from a range of pages",
+      title: "Paginação",
+      description:
+        "A paginação permite a seleção de uma variedade de páginas dentro de um intervalo.",
       checklist: {
         "c-pagination-selected": {
-          title: "Selected page state",
+          title: "Estado da página selecionada",
           description:
-            "Visually highlight the selected page in the list and make it non-interactive.",
+            "Destaque visualmente a página selecionada na lista e torne-a não interativa.",
         },
         "c-pagination-ranges": {
-          title: "Page display ranges",
+          title: "Intervalos de exibição de páginas",
           description:
-            "Define the ranges for pages rendered around the selected page. It helps render only a limited number of pages but lets the users navigate faster than moving by 1 page at a time.",
+            "Defina os intervalos de páginas a serem renderizadas ao redor da página selecionada. Isso ajuda a exibir apenas um número limitado de páginas, permitindo que os usuários naveguem mais rapidamente do que se tivessem que avançar uma página de cada vez.",
         },
         "c-pagination-amount": {
-          title: "Amount of items per page",
+          title: "Quantidade de itens por página",
           description:
-            "Provide an option to select the number of paginated items displayed on the page.",
+            "Forneça uma opção para selecionar o número de itens paginados exibidos na página.",
         },
         "c-pagination-indeterminate": {
-          title: "Indeterminate amount of pages",
+          title: "Quantidade indeterminada de páginas",
           description:
-            "When you don’t know the total number of available pages beforehand, use a different display mode to navigate pages individually.",
+            "Quando você não conhece antecipadamente o número total de páginas disponíveis, utilize um modo de exibição diferente que permita navegar pelas páginas individualmente.",
         },
         "c-pagination-a11y-label": {
-          title: "Full page label announcements",
+          title: "Labels de paginação",
           description:
-            "Pagination should provide clear, dynamic labels for each page for assistive technologies instead of just announcing the number without context.",
+            "A paginação deve fornecer labels claras e dinâmicas para cada página, a fim de oferecer informações contextuais às tecnologias assistivas, em vez de apenas anunciar o número da página sem contexto.",
         },
         "c-pagination-a11y-state": {
-          title: "State announcement",
+          title: "Anúncio de estado",
           description:
-            "Pagination should announce when a selected page is focused.",
+            "A paginação deve anunciar quando uma página selecionada está em foco.",
         },
       },
     },
     "c-progress": {
-      title: "Progress bar",
+      title: "Barra de progresso",
       description:
-        "Bar displaying progress for a task that takes a long time or consists of several steps.",
+        "Barra de progresso que exibe o avanço de uma tarefa que leva muito tempo ou consiste em várias etapas.",
       checklist: {
         "c-progress-label": {
           title: "Label",
           description:
-            "Provide support for visually displaying a label explaining what a progress bar is responsible for.",
+            "Ofereça suporte para exibir visualmente uma label que explique qual é a responsabilidade da barra de progresso.",
         },
         "c-progress-sizes": {
-          title: "Sizes",
+          title: "Tamanhos",
           description:
-            "Loading indicators might provide multiple sizes, depending on the size of the areas where the loading indicator is rendered.",
+            "Os indicadores de carregamento podem oferecer diferentes tamanhos, dependendo do tamanho das áreas em que são renderizados.",
         },
         "c-progress-duration": {
-          title: "Duration",
+          title: "Duração",
           description:
-            "In some cases, the wait time can’t be determined. The loading indicator should be shown until the loading finishes or an error happens. In other cases, it’s better to indicate the time left until the loading is complete.",
+            "Em alguns casos, o tempo de espera não pode ser determinado. O indicador de carregamento deve ser exibido até que o carregamento seja concluído ou ocorra um erro. Em outras situações, é preferível indicar o tempo restante até que o carregamento seja concluído.",
         },
         "c-progress-a11y-label": {
-          title: "Accessibility label",
+          title: "Label de acessibilidade",
           description:
-            "Provide support for adding an accessibility label in case you can’t display a label in the interface.",
+            "Forneça suporte para adicionar uma label acessível caso não seja possível exibir um rótulo na interface.",
         },
       },
     },
     "c-radio": {
-      title: "Input radio",
+      title: "Radio",
       description:
-        "Radio is a form element used for selecting one option from a list.",
+        "O radio é um elemento de formulário usado para selecionar uma opção em uma lista.",
       checklist: {
         "c-radio-label": {
           title: "Label",
           description:
-            "There should be a text label linked with the radio field. Clicking the label should also trigger the checkbox selection. If the label is not rendered on the page, assistive technologies should still announce it.",
+            "Deve haver uma label de texto vinculada ao radio. Clicar na label também deve acionar a marcação do checkbox. Se a label não for renderizada na página, as tecnologias assistivas ainda devem anunciá-la.",
         },
         "c-radio-checked": {
-          title: "Checked state",
+          title: "Estado selecionado",
           description:
-            "Display when the radio gets selected and is used for the form submission.",
+            "Exiba quando o radio está selecionado e é utilizado para o envio do formulário",
         },
         "c-radio-error": {
-          title: "Error state",
+          title: "Estado de erro",
           description:
-            "Use an error state for form validation when the error is related to the radio field. Always use a text error along with a different field color.",
+            "Use um estado de erro para validação de formulário quando o erro estiver relacionado ao componente de radio. Sempre use um texto de erro junto com uma cor de campo diferente.",
         },
         "c-radio-disabled": {
-          title: "Disabled state",
+          title: "Estado desativado",
           description:
-            "Use a disabled state to prevent radio interactions and remove its value from the submitted form values.",
+            "Utilize um estado desativado para evitar interações com os botões de radio e remova o seu valor dos valores enviados pelo formulário.",
         },
         "c-radio-group": {
-          title: "Radio group",
+          title: "Grupo de radios",
           description:
-            "Radio buttons are always used as a group to avoid locking the selection after one of the radio buttons is checked.",
+            "Os botões de radio são sempre usados em grupo para evitar a fixação da seleção após um dos botões de radio ser marcado.",
         },
         "c-radio-a11y-keyboard": {
-          title: "Keyboard support",
+          title: "Suporte ao teclado",
           description:
-            "Radio selection should be triggered with the keyboard. Using native elements for this should provide this kind of interaction automatically.",
+            "A seleção do radio deve ser acionada com o teclado. O uso de elementos nativos para isso deve proporcionar esse tipo de interação automaticamente.",
         },
       },
     },
     "c-select": {
       title: "Select",
       description:
-        "Select lets you choose a single value from a list of options.",
+        "O select permite que você escolha um único valor em uma lista de opções.",
       checklist: {
         "c-select-label": {
           title: "Label",
           description:
-            "Text labels linked with the Select field can provide users with additional context. Clicking the label should also trigger the select dropdown.",
+            "Labels de texto vinculadas ao campo de select podem fornecer aos usuários um contexto adicional. Clicar na label também deve abrir o dropdown.",
         },
         "c-select-error": {
-          title: "Error state",
+          title: "Estado de erro",
           description:
-            "Use an error state for form validation when the error is related to the select only. Display an additional error icon for better accessibility.",
+            "Utilize um estado de erro para validação do formulário quando o erro estiver relacionado apenas à seleção. Exiba um ícone de erro adicional para melhor a acessibilidade.",
         },
         "c-select-disabled": {
-          title: "Disabled state",
+          title: "Estado desativado",
           description:
-            "Use the disabled state to prevent Select interactions and remove its value from the submitted form values.",
+            "Utilize um estado desativado para impedir interações com o select e remova o seu valor dos valores enviados pelo formulário.",
         },
         "c-select-placeholder": {
           title: "Placeholder",
           description:
-            "When no value is selected – display a placeholder value. You can use the same placeholder value to let users reset the select value back to the default.",
+            "Quando nenhum valor é selecionado, exiba um placeholder. Você pode usar o mesmo valor do placeholder para permitir que os usuários redefinam o valor da seleção de volta para o padrão.",
         },
         "c-select-helper": {
-          title: "Helper text",
+          title: "Texto auxiliar",
           description:
-            "Provide users with additional context about the select purpose and the requirements for the selection.",
+            "Forneça aos usuários um contexto adicional sobre o propósito da seleção e os requisitos para a escolha.",
         },
         "c-select-icon": {
-          title: "Icon support",
+          title: "Suporte a ícones",
           description:
-            "Add an area for displaying an icon at the start of the field to communicate the purpose of the Select as a component or the selected value.",
+            "Adicione uma área para exibir um ícone no início do campo para comunicar o propósito do select como um componente ou o valor selecionado.",
         },
         "c-select-prefix": {
-          title: "Prefix",
+          title: "Prefixo",
           description:
-            "Add an area for custom content to make the selection more contextual for the user. For example, you can display country flags in your country code selection.",
+            "Adicione uma área para conteúdo personalizado para tornar a seleção mais contextual para o usuário. Por exemplo, você pode exibir bandeiras de países na seleção de códigos de país.",
         },
         "c-select-sizes": {
-          title: "Sizes",
+          title: "Tamanhos",
           description:
-            "Depending on where select is going to be used, it can come in multiple sizes. For example, you can use the small size for dense areas of your application.",
+            "Dependendo de onde a seleção será usada, ela pode ter vários tamanhos. Por exemplo, você pode usar o tamanho pequeno para áreas mais densas da sua aplicação.",
         },
         "c-select-a11y-label": {
-          title: "Accessibility label",
+          title: "Label de acessibilidade",
           description:
-            "In case you don’t provide a visual text label for select, make sure to provide an accessibility label still describing the purpose of the component.",
+            "Se você não fornecer uma label de texto visual para a seleção, certifique-se de fornecer uma label acessível que ainda descreva o propósito do componente.",
         },
       },
     },
     "c-skeleton": {
       title: "Skeleton",
       description:
-        "Placeholder replacing page elements while their data is loading.",
+        "Placeholder que substitui elementos da página enquanto os dados estão sendo carregados.",
       checklist: {
         "c-skeleton-sizes": {
-          title: "Sizes",
+          title: "Tamanhos",
           description:
-            "Skeleton should be able to match components of various sizes available in your design system to avoid unnecessary layout shifts once data is loaded.",
+            "O skeleton deve ser capaz de se adaptar aos componentes de vários tamanhos disponíveis no seu design system, evitando deslocamentos de layout desnecessários assim que os dados forem carregados.",
         },
         "c-skeleton-shapes": {
-          title: "Shapes",
+          title: "Formatos",
           description:
-            "Skeleton should be able to match components of various shapes available in your design system to keep the loading state aligned with the actual components' layout.",
+            "O Skeleton deve ser capaz de se adequar aos componentes de várias formas disponíveis no seu design system, garantindo que o estado de carregamento esteja alinhado com o layout real dos componentes.",
         },
         "c-skeleton-composition": {
-          title: "Composition",
+          title: "Composição",
           description:
-            "You can compose simple skeletons into more advanced layouts. You don’t have to 1:1 map your application interface with skeletons.",
+            "Você pode compor skeletons simples em layouts mais avançados. Você não precisa mapear a interface do seu aplicativo 1:1 com os skeletons.",
         },
         "c-skeleton-a11y-motion": {
-          title: "Reduced motion",
+          title: "Animação reduzida",
           description:
-            "Reduce or altogether remove the animation for the reduced motion user preference.",
+            "Reduza ou remova completamente a animação para a preferência do usuário com movimento reduzido.",
         },
       },
     },
     "c-switch": {
       title: "Switch",
       description:
-        "Toggle for immediately changing the state of a single item.",
+        "Toggle para alterar imediatamente o estado de um único item.",
       checklist: {
         "c-switch-label": {
           title: "Label",
           description:
-            "There should be a text label linked with the switch. Clicking the label should also trigger the switch selection. If the label is not rendered on the page, assistive technologies should still announce it.",
+            "Deve haver uma label de texto associada ao switch. Clicar na label também deve ativar a seleção do switch. Se a label não estiver visível na página, as tecnologias assistivas ainda devem anunciá-la.",
         },
         "c-switch-checked": {
-          title: "Checked state",
+          title: "Estado selecionado",
           description:
-            "Display when the switch gets selected and activates the underlying functionality. Often, a switch is used to immediately update the data after it’s selected.",
+            "Exiba quando o switch é selecionado e ative a funcionalidade subjacente. Frequentemente, um switch é usado para atualizar imediatamente os dados após ser selecionado.",
         },
         "c-switch-disabled": {
-          title: "Disabled state",
-          description: "Use a disabled state to prevent switch interactions.",
+          title: "Estado desativado",
+          description:
+            "Utilize o estado desativado para impedir interações com o switch.",
         },
         "c-switch-a11y-keyboard": {
-          title: "Keyboard navigation",
+          title: "Navegação por teclado",
           description:
-            "Switch selection should be triggered with the keyboard. Using native elements for this should provide this kind of interaction automatically.",
+            "A seleção do switch deve ser acionada pelo teclado. O uso de elementos nativos para isso deve fornecer esse tipo de interação automaticamente.",
         },
         "c-switch-a11y-label": {
-          title: "Accessibility label",
+          title: "Label de acessibilidade",
           description:
-            "In case you don’t provide a visual text label for Switch, make sure to provide an accessibility label still describing the purpose of the component.",
+            "Caso você não forneça uma label de texto visual para o switch, certifique-se de fornecer uma label acessível que descreva o propósito do componente.",
         },
       },
     },
     "c-tabs": {
       title: "Tabs",
-      description: "Navigation between multiple pages or content sections.",
+      description: "Navegação entre várias páginas ou seções de conteúdo.",
       checklist: {
         "c-tabs-composition": {
-          title: "Content composition",
+          title: "Composição de conteúdo",
           description:
-            "Content area should be flexible enough to support various types of content, including other components.",
+            "A área de conteúdo deve ser flexível o suficiente para suportar diversos tipos de conteúdo, incluindo outros componentes.",
         },
         "c-tabs-variants": {
-          title: "Variants",
+          title: "Variantes",
           description:
-            "To support different rendering contexts, tabs might support multiple variants. For example, they might be rendered as pills when used directly on the page while using an underlined variant for tabs rendered inside cards.",
+            "Para suportar diferentes contextos de renderização, as tabs podem ter várias variantes. Por exemplo, elas podem ser renderizadas como pills quando usadas diretamente na página, enquanto utilizam uma variante sublinhada para abas renderizadas dentro de cards.",
         },
         "c-tabs-selected": {
-          title: "Selected state",
+          title: "Estado selecionado",
           description:
-            "Since tabs always display the content from one of their panels, one of the tab triggers should always be selected and highlighted visually.",
+            "Como as tabs sempre exibem o conteúdo de um de seus painéis, um dos acionadores da tab deve estar sempre selecionado e destacado visualmente.",
         },
         "c-tabs-disabled": {
-          title: "Disabled state",
+          title: "Estado desativado",
           description:
-            "Tab triggers can be disabled to prevent users from switching to a specific tab panel.",
+            "Os acionadores das tabs podem ser desativados para evitar que os usuários alterem para um painel de tab específico.",
         },
         "c-tabs-icon": {
-          title: "Icon support",
+          title: "Suporte a ícones",
           description:
-            "To better illustrate the meaning of each tab, you can display an icon next to the tab trigger text.",
+            "Para ilustrar melhor o significado de cada tab, você pode exibir um ícone ao lado do texto do acionador da tab.",
         },
         "c-tabs-equal": {
-          title: "Equal width layout",
+          title: "Layout de largura igual",
           description:
-            "When used to take the entire width of the parent container, tab triggers can be stretched to take equal horizontal space.",
+            "Quando usados para ocupar toda a largura do contêiner pai, os acionadores das tabs podem ser esticados para ocupar espaços horizontais iguais.",
         },
         "c-tabs-a11y-keyboard": {
-          title: "Keyboard suppoort",
+          title: "Suporte ao teclado",
           description:
-            "When interacting with tabs using the keyboard, they should support arrow navigation to switch between the previous and next panels. The Home and End buttons should also move the selection to the first and last panels, respectively.",
+            "Ao interagir com as tabs usando o teclado, elas devem suportar a navegação com as setas para alternar entre os painéis anterior e próximo. Os botões Home e End também devem mover a seleção para o primeiro e último painéis, respectivamente.",
         },
       },
     },
     "c-text-area": {
-      title: "Text area",
-      description: "Form field to enter and edit multiline text.",
+      title: "Área de texto",
+      description:
+        "Campo de formulário para inserir e editar texto multilinha.",
       checklist: {
         "c-text-area-label": {
           title: "Label",
           description:
-            "Text labels linked with the text area can provide users with additional context. Clicking the label should move the focus to the field.",
+            "Labels de texto vinculadas à área de texto podem fornecer aos usuários um contexto adicional. Clicar na label deve mover o foco para o campo.",
         },
         "c-text-area-error": {
-          title: "Error state",
+          title: "Estado de erro",
           description:
-            "Use an error state for form validation when the error is related only to the Text area.",
+            "Use um estado de erro para a validação do formulário quando o erro estiver relacionado apenas à área de texto.",
         },
         "c-text-area-disabled": {
-          title: "Disabled state",
+          title: "Estado desativado",
           description:
-            "Use a disabled state to prevent text area interactions and remove its value from the submitted form values.",
+            "Use o estado desabilitado para impedir interações com a área de texto e remover o seu valor dos valores do formulário enviados.",
         },
         "c-text-area-placeholder": {
           title: "Placeholder",
           description:
-            "When the text area value is empty – display a placeholder value. Make sure that it’s not used instead of the label.",
+            "Quando o valor da área de texto estiver vazio, exiba um valor placeholder. Certifique-se de que ele não seja usado no lugar da label.",
         },
         "c-text-area-helper": {
-          title: "Helper text",
+          title: "Texto auxiliar",
           description:
-            "Provide users with additional context about the Text area purpose and the requirements for the expected value.",
+            "Forneça aos usuários um contexto adicional sobre o objetivo da área de texto e os requisitos para o valor esperado.",
         },
         "c-text-area-sizes": {
-          title: "Sizes",
+          title: "Tamanhos",
           description:
-            "Depending on where the text area will be used, it can come in multiple sizes. For example, you can use the large size for the forms on marketing pages.",
+            "Dependendo de onde a text rea será usada, ela pode ter vários tamanhos. Por exemplo, você pode usar o tamanho grande para os formulários em páginas de marketing.",
         },
         "c-text-area-a11y-label": {
-          title: "Accessibility label",
+          title: "Label de acessibilidade",
           description:
-            "In case you don’t provide a visual text label for the text area, make sure to provide an accessibility label still describing the purpose of the component.",
+            "Caso não seja fornecida uma label de texto visual para a área de texto, certifique-se de fornecer uma label acessível que descreva o propósito do componente.",
         },
       },
     },
     "c-text-field": {
-      title: "Text field",
-      description: "Form field to enter and edit single-line text.",
+      title: "Campo de texto",
+      description:
+        "Campo de formulário para inserir e editar texto de uma única linha.",
       checklist: {
         "c-text-field-label": {
           title: "Label",
           description:
-            "Text labels linked with the text field can provide users with additional context. Clicking the label should move the focus to the field.",
+            "Labels de texto vinculadas ao campo de texto podem fornecer aos usuários um contexto adicional. Clicar na label deve mover o foco para o campo.",
         },
         "c-text-field-error": {
-          title: "Error state",
+          title: "Estado de erro",
           description:
-            "Use an error state for form validation when the error is related only to the text field.",
+            "Use um estado de erro para a validação do formulário quando o erro estiver relacionado apenas ao campo de texto.",
         },
         "c-text-field-disabled": {
-          title: "Disabled state",
+          title: "Estado desativado",
           description:
-            "Use a disabled state to prevent text field interactions and remove its value from the submitted form values.",
+            "Use o estado desabilitado para impedir interações com o campo de texto e remover o seu valor dos valores do formulário enviados.",
         },
         "c-text-field-placeholder": {
           title: "Placeholder",
           description:
-            "When the text field value is empty – display a placeholder value. Make sure that it’s not used instead of the label.",
+            "Quando o valor do campo de texto estiver vazio, exiba um valor placeholder. Certifique-se de que ele não seja usado no lugar da label.",
         },
         "c-text-field-helper": {
-          title: "Helper text",
+          title: "Texto auxiliar",
           description:
-            "Provide users with additional context about the text field purpose and the requirements for the expected value.",
+            "Forneça aos usuários um contexto adicional sobre o objetivo do campo de texto e os requisitos para o valor esperado.",
         },
         "c-text-field-icon": {
-          title: "Icon support",
+          title: "Suporte a ícones",
           description:
-            "Add an area for displaying an icon at the start of the field to communicate the purpose of the text field as a component or the field value.",
+            "Adicione uma área para exibir um ícone no início do campo para comunicar o objetivo do campo de texto como um componente ou o valor do campo.",
         },
         "c-text-field-affix": {
-          title: "Prefix / Suffix",
+          title: "Prefixo / Sufixo",
           description:
-            "Add an area for custom content to make the selection more contextual for the user. For example, you can display payment providers in the text field for credit card numbers.",
+            "Adicione uma área para conteúdo personalizado para tornar a seleção mais contextual para o usuário. Por exemplo, você pode exibir provedores de pagamento no campo de texto para números de cartão de crédito.",
         },
         "c-text-field-sizes": {
-          title: "Sizes",
+          title: "Tamanhos",
           description:
-            "Depending on where the text field will be used, it can come in multiple sizes. For example, you can use the large size for the forms on marketing pages.",
+            "Dependendo de onde o campo de texto será usado, ele pode ter vários tamanhos. Por exemplo, você pode usar o tamanho grande para os formulários em páginas de marketing.",
         },
         "c-text-field-a11y-label": {
-          title: "Accessibility label",
+          title: "Label de acessibilidade",
           description:
-            "In case you don’t provide a visual text label for the text field, make sure to provide an accessibility label still describing the purpose of the component.",
+            "Caso você não forneça uma etiqueta visual de texto para o campo de texto, certifique-se de fornecer uma label acessível que descreva o propósito do componente.",
         },
       },
     },
     "c-toast": {
       title: "Toast",
       description:
-        "Notification message or a piece of information displayed above the page content.",
+        "Mensagem de notificação ou uma informação exibida acima do conteúdo da página.",
       checklist: {
         "c-toast-composition": {
-          title: "Content composition",
+          title: "Composição de conteúdo",
           description:
-            "Content area should be flexible enough to support various types of content, including other components.",
+            "A área de conteúdo deve ser flexível o suficiente para suportar vários tipos de conteúdo, incluindo outros componentes.",
         },
         "c-toast-colors": {
-          title: "Colors",
+          title: "Cores",
           description:
-            "Depending on the role of the notification displayed in the toast, it can come in multiple colors. For example, it can be colored red for error notifications.",
+            "Dependendo da função da notificação exibida no toast, ela pode ter cores diferentes. Por exemplo, pode ser vermelha para notificações de erro.",
         },
         "c-toast-icon": {
-          title: "Icon support",
+          title: "Suporte a ícones",
           description:
-            "Add an area for displaying an icon at the start of the toast to communicate the purpose of the notification.",
+            "Adicione uma área para exibir um ícone no início do toast para comunicar o objetivo da notificação. Isso ajudará os usuários a identificarem rapidamente o tipo de notificação e sua finalidade.",
         },
         "c-toast-timeout": {
           title: "Timeout",
           description:
-            "Toasts are usually dismissed after a timeout. Make sure to provide a long enough timeout to let the users read the message. If there is no timeout – provide a button to close the notification.",
+            "Os toasts geralmente são fechados automaticamente após um determinado período de tempo. Certifique-se de fornecer um tempo de duração suficientemente longo para que os usuários possam ler a mensagem. Caso não haja um tempo de duração definido, inclua um botão para fechar a notificação.",
         },
         "c-toast-stacking": {
-          title: "Stacking",
+          title: "Empilhamento",
           description:
-            "When multiple toasts have been triggered, stack them on top of each other to avoid cluttering the screen.",
+            "Quando vários toasts são acionados, empilhe-os um sobre o outro para evitar a desordem na tela.",
         },
         "c-toast-action": {
-          title: "Supplementary action",
+          title: "Ação suplementar",
           description:
-            "Actions in the notifications should be contextual to the notification purpose. For example, if you notify the user about deleting content, an action element can help them undo this operation.",
+            "As ações nas notificações devem ser contextuais ao propósito da notificação. Por exemplo, se você notificar o usuário sobre a exclusão de conteúdo, um elemento de ação pode ajudá-lo a desfazer essa operação.",
         },
         "c-toast-a11y-focus": {
-          title: "Focus management",
+          title: "Gerenciamento de foco",
           description:
-            "When toasts have actions, they should be focusable from the keyboard to trigger them. While the focus is inside the toast container – timeout should get disabled.",
+            "Quando os toasts possuem ações, elas devem ser acessíveis por meio do teclado para serem acionadas. Enquanto o foco estiver dentro do contêiner do toast, o timeout deve ser desabilitado.",
         },
         "c-toast-a11y-motion": {
-          title: "Reduced motion",
+          title: "Animação reduzida",
           description:
-            "Reduce or altogether remove the animation for the reduced motion user preference.",
+            "Reduza ou remova completamente a animação para a preferência do usuário com movimento reduzido.",
         },
       },
       "c-tooltip": {
         title: "Tooltip",
         description:
-          "Contextual text information display on element hover or focus.",
+          "Exibição de informações textuais contextuais ao passar o mouse ou focar em um elemento.",
         checklist: {
           "c-tooltip-positioning": {
-            title: "Positioning",
+            title: "Posicionamento",
             description:
-              "When the tooltip default position doesn’t let it fit into the viewport – make sure to dynamically switch its position to another value.",
+              "Quando a posição padrão da tooltip não permite que ela caiba na tela, certifique-se de alternar dinamicamente sua posição para outro valor.",
           },
           "c-tooltip-timeout": {
             title: "Timeout",
             description:
-              "Wait briefly before opening the Tooltip to ensure they don’t open while the user moves their cursor around the screen.",
+              "Aguarde brevemente antes de abrir a tooltip para garantir que ela não seja aberta enquanto o usuário move o cursor pela tela.",
           },
           "c-tooltip-a11y-keyboard": {
-            title: "Keyboard support",
+            title: "Suporte ao teclado",
             description:
-              "Tooltips should be accessible not only on mouse hover but also on the trigger element focus. ",
+              "As tooltips devem ser acessíveis não apenas ao passar o mouse sobre o elemento acionador, mas também ao focar nele.",
           },
         },
       },

--- a/src/translations/pt/core.js
+++ b/src/translations/pt/core.js
@@ -1,30 +1,30 @@
 export default {
-  heroTitle: "Construa Design Systems melhores",
+  heroTitle: "Construa design systems melhores",
   heroSubtitle:
-    "Um checklist de código aberto para te ajudar a planejar, construir e expandir seu Design System.",
+    "Um checklist de código aberto para te ajudar a planejar, construir e expandir seu design system.",
   heroAction: "Comece agora",
-  
+
   more: "Precisa de mais?",
   about: "Sobre",
   share: "Compartilhar",
   contribute: "Contribuir",
-  
+
   previous: "Anterior",
   next: "Próximo",
-  
+
   exportTitle: "Compartilhe",
   exportSubtitle:
-    "Os Design Systems são melhores construídos em conjunto. É por isso que tornamos possível compartilhar este checklist, incluindo os itens que você já verificou. Compartilhe seu progresso com sua equipe para que todos possam acompanhar juntos.",
+    "Design systems são melhor construídos em conjunto. É por isso que tornamos possível compartilhar este checklist, incluindo os itens que você já marcou. Compartilhe seu progresso com sua equipe para que todos possam acompanhar juntos.",
   exportAction: "Compartilhe seu progresso",
   exportComplete: "Link copiado",
-  
+
   moreTitle: "Procurando por mais?",
   moreText:
-    "Usamos este checklist para construir o Reshaped, um Design System profissionalmente elaborado para Figma e React. O Reshaped oferece licenças em pacote com atualizações ilimitadas, acesso ao código-fonte do sistema e consultoria focada em Design Systems.",
+    "Usamos este checklist para construir o Reshaped, um design system profissionalmente elaborado para Figma e React. Ao longo dos anos, vimos tendências surgirem e desaparecerem, enquanto os desafios fundamentais persistiam. Por isso, optamos por nos concentrar em questões que serão relevantes por muitos anos e criamos nossa própria abordagem que funciona em qualquer escala. Nossa experiência de mais de 10 anos resultou em um design system white-label que utilizamos internamente e agora estamos disponibilizamos para outras pessoas.",
   moreAction: "Saiba mais",
-  
+
   footerTitle: "Precisa de mais do que um checklist?",
   footerText:
-    "Usamos este checklist para construir o Reshaped, um Design System profissionalmente elaborado para Figma e React. O Reshaped oferece licenças em pacote com atualizações ilimitadas, acesso ao código-fonte do sistema e consultoria focada em Design Systems.",
+    "Usamos este checklist para construir o Reshaped, um design system profissionalmente elaborado para Figma e React. O Reshaped oferece licenças regulares de pacote com atualizações ilimitadas, acesso ao código-fonte do sistema e consultoria focada em design systems.",
   footerAction: "Saiba mais",
 };

--- a/src/translations/pt/designFoundations.js
+++ b/src/translations/pt/designFoundations.js
@@ -1,177 +1,177 @@
 export default {
-  title: "Foundations",
+  title: "Fundamentos",
   description:
-    "Design assets and tokens that store values for the base layer of your design system, like color and typography. They’re used in components, so changes on this level will resonate throughout the whole system.",
+    "Elementos de design e tokens são elementos que armazenam os valores fundamentais do seu sistema de design, como cores e tipografia. Eles são usados nos componentes, portanto, as alterações nesse nível terão impacto em todo o sistema.",
   sections: {
     "df-color": {
-      title: "Color",
+      title: "Cor",
       description:
-        "Not only an efficient way to showcase your brand but also an efficient way to communicate with your users. Color palettes created with purpose over aesthetics in mind can help you develop intuitive design patterns by adding meaning to your interface.",
+        "Não apenas uma forma eficiente de exibir sua marca, mas também uma maneira eficaz de se comunicar com seus usuários. Paletas de cores criadas com propósito, em vez de apenas estética, podem ajudar você a desenvolver padrões de design intuitivos, adicionando significado à sua interface.",
       checklist: {
         "df-color-a11y": {
-          title: "Accessibility",
+          title: "Acessibilidade",
           description:
-            "Make sure to have accessible pairings between the primary colors in your palette. More importantly, ensure that your background and text colors have at least an AA standard contrast ratio.",
+            "Certifique-se de ter combinações acessíveis entre as cores principais da sua paleta. Além disso, é fundamental garantir que as cores de fundo e de texto tenham um índice de contraste mínimo de acordo com o padrão AA.",
         },
         "df-color-semantic": {
-          title: "Semantic colors",
+          title: "Cores semânticas",
           description:
-            "Besides your brand colors, make sure to have colors defined and made into variables for functions like disabled states, backgrounds, actions, and high-contrast text.",
+            "Além das cores da sua marca, assegure-se de definir e utilizar cores em variáveis para funções como estados desativados, fundos, ações e texto de alto contraste.",
         },
         "df-color-dark-mode": {
-          title: "Dark mode",
+          title: "Tema escuro",
           description:
-            "Preparing a dark mode version of your color palette will allow your design system to adapt to the user's OS color preferences.",
+            "Preparar uma versão de tema escuro da sua paleta de cores permitirá que o seu design system se adapte às preferências de cor do sistema operacional do usuário.",
         },
         "df-color-guidelines": {
-          title: "Guidelines",
+          title: "Diretrizes",
           description:
-            "Provide guidelines on how and when to use the colors in your palette, what to keep in mind when working with them, and how not to use them.",
+            "Disponibilize diretrizes sobre como e quando utilizar as cores da sua paleta, incluindo informações importantes a serem consideradas ao trabalhar com elas, bem como orientações sobre como evitar usos inadequados.",
         },
       },
     },
     "df-layout": {
       title: "Layout",
       description:
-        "A well-thought-out layout goes a long way. Consistent use of a grid and spacing makes it easier for your users to scan the user interface and grasp the content.",
+        "Um layout bem planejado faz toda a diferença. Ao utilizar um grid e espaçamentos de forma consistente, você facilita a escaneabilidade da interface pelo usuário e a compreensão do conteúdo",
       checklist: {
         "df-layout-units": {
-          title: "Units",
+          title: "Unidades",
           description:
-            "Units are the most granular building blocks for layout. Defining a set of values with consistent increments (such as 4, 8, 12, and 16 for a 4-point system) will provide the foundation for designing your grid and spacing values.",
+            "As unidades são os elementos de construção mais granulares do layout. Ao definir um conjunto de valores com incrementos consistentes (como 4, 8, 12 e 16 para um sistema de 4 pontos), você estabelece a base para projetar os valores do grid e de espaçamento.",
         },
         "df-layout-grid": {
           title: "Grid",
           description:
-            "Every layout should sit on a grid that brings order and hierarchy to the interface. Define a grid separately for mobile, tablet, and desktop devices with columns, gutters, and margins so your interface can adapt to any platform quickly.",
+            "Cada layout deve se basear em um grid que traga ordem e hierarquia para a interface. Defina uma grade separadamente para dispositivos móveis, tablets e desktops, com colunas, espaçamentos e margens, para que sua interface possa se adaptar de forma ágil a qualquer plataforma.",
         },
         "df-layout-breakpoints": {
           title: "Breakpoints",
           description:
-            "Predefine the screen sizes and orientations your grid will adapt to.",
+            "Pré-defina os tamanhos de tela e orientações às quais seu grid irá se adaptar.",
         },
         "df-layout-spacing": {
-          title: "Spacing",
+          title: "Espaçamento",
           description:
-            "Horizontal and vertical rhythm plays a significant role in a layout. You should provide straightforward methods for adding space between interface elements independent of your grid.",
+            "O ritmo horizontal e vertical desempenha um papel significativo em um layout. Você deve fornecer métodos diretos para adicionar espaçamento entre os elementos da interface, independentemente do seu grid.",
         },
       },
     },
     "df-typography": {
-      title: "Typography",
+      title: "Tipografia",
       description:
-        "Typography is one of the main ways you surface content in products. A clear hierarchy and contrasting styles in your typography scale will make things easier to read and help with the overall structure of your product. It’s also an opportunity to visualize your brand character and presence.",
+        "A tipografia é uma das principais formas de apresentar conteúdo em produtos. Uma hierarquia clara e estilos contrastantes na escala tipográfica facilitarão a leitura e contribuirão para a estrutura geral do seu produto. É também uma oportunidade para visualizar a personalidade e presença da sua marca.",
       checklist: {
         "df-typography-mobile": {
-          title: "Responsiveness",
+          title: "Responsividade",
           description:
-            "Desktop devices can usually afford to have bigger font sizes compared to mobile devices. Creating a typography scale that adapts to the viewport size will help with a more meaningful hierarchy and layout.",
+            "Em dispositivos desktop, é comum utilizar tamanhos de fonte maiores em comparação com dispositivos móveis. Criar uma escala tipográfica que se adapte ao tamanho da tela ajudará a estabelecer uma hierarquia e um layout mais coerentes e significativos.",
         },
         "df-typography-grid": {
-          title: "Grid relation",
+          title: "Relação do grid",
           description:
-            "Font sizes and leading should match your grid to allow better pairing between text and other UI elements. A good example of this is text paired with icons with bounding boxes.",
+            "Os tamanhos de fonte e o espaçamento devem estar alinhados com o seu grid para permitir uma melhor harmonização entre o texto e os demais elementos da interface. Um bom exemplo disso é o texto combinado com ícones que possuam caixas delimitadoras.",
         },
         "df-typography-readability": {
-          title: "Readability",
+          title: "Legibilidade",
           description:
-            "Optimizing the letter spacing (tracking), line height (leading) and line length for your typography scale will help with the readability of text.",
+            "Otimizar o espaçamento entre letras (tracking), a altura das linhas (leading) e o comprimento das linhas para a sua escala tipográfica ajudará na legibilidade do texto.",
         },
         "df-typography-performance": {
-          title: "Performance",
+          title: "Desempenho",
           description:
-            "Custom fonts need to be downloaded before they can be displayed, especially on the web. Make sure that you have sensible fallbacks and fast loading time for your typography assets. Using system fonts solves this performance problem.",
+            "Fontes personalizadas precisam ser baixadas antes de serem exibidas, especialmente na web. Certifique-se de ter substituições adequadas e um tempo de carregamento rápido para seus recursos tipográficos. Utilizar fontes do sistema resolve esse problema de desempenho.",
         },
         "df-typography-guidelines": {
-          title: "Guidelines",
+          title: "Diretrizes",
           description:
-            "Provide guidelines on how and when to use the pairings in your typography scale, what to keep in mind when working with them, and how not to use them.",
+            "Disponibilize diretrizes sobre como e quando utilizar as combinações da sua escala tipográfica, incluindo informações importantes a serem consideradas ao trabalhar com elas, e orientações sobre como evitar usos inadequados.",
         },
       },
     },
     "df-elevation": {
-      title: "Elevation",
+      title: "Elevação",
       description:
-        "Elevation controls the relative distance between two surfaces along the z-axis. In light mode, it’s usually highlighted by the shadow value applied to a surface, while in dark mode, it’s communicated using the background color value.",
+        "A elevação controla a distância relativa entre duas superfícies ao longo do eixo z. No modo claro, geralmente é destacada pelo valor de sombra aplicado a uma superfície, enquanto no modo escuro, é comunicada usando o valor da cor de fundo.",
       checklist: {
         "df-elevation-shadows": {
-          title: "Shadows",
+          title: "Sombras",
           description:
-            "Provide multiple shadow values based on the supported elevation levels. Most of the time, you will need 3 to 4 elevation levels in your product.",
+            "Forneça múltiplos valores de sombra com base nos níveis de elevação suportados. Na maioria das vezes, você precisará de 3 a 4 níveis de elevação em seu produto..",
         },
         "df-elevation-background": {
-          title: "Background colors",
+          title: "Cores de fundo",
           description:
-            "Each shadow value should have a linked background color. In light mode, these colors might all resolve to the white color since it’s used together with the shadow. In dark mode, they will be used instead of the shadow to communicate the z-axis distance of a surface.",
+            "Cada valor de sombra deve ter uma cor de fundo associada. No modo claro, essas cores podem ser todas resolvidas para a cor branca, já que são usadas juntamente com a sombra. No modo escuro, elas serão utilizadas em vez da sombra para comunicar a distância do eixo-z de uma superfície.",
         },
         "df-elevation-z": {
           title: "Z-index",
           description:
-            "Define a system of z-index values to control which elements have priority to be rendered on top of the others.",
+            "Defina um sistema de valores de z-index para controlar quais elementos têm prioridade para serem renderizados acima dos outros.",
         },
       },
     },
     "df-motion": {
       title: "Motion",
       description:
-        "Shared motion values provide a more coherent user experience and better alignment with the brand.",
+        "O uso de valores de motion compartilhados proporciona uma experiência do usuário mais coerente e alinhada com a identidade da marca.",
       checklist: {
         "df-motion-easing": {
           title: "Easing",
           description:
-            "Provide standard easing functions used across the system for component transitions. As a start, you can use standard, accelerated and decelerated functions that should cover common component use cases.",
+            "Forneça funções de easing padrão usadas em todo o sistema para as transições dos componentes. Como ponto de partida, você pode usar funções de easing padrão, aceleradas e desaceleradas, que devem abranger os casos de uso comuns dos componentes.",
         },
         "df-motion-duration": {
-          title: "Duration",
+          title: "Duração",
           description:
-            "Define multiple values for your animation duration to keep the component transitions consistent across the product",
+            "Defina múltiplos valores para a duração da animação para manter as transições de componentes consistentes em todo o produto.",
         },
         "df-motion-a11y": {
-          title: "Accessibility",
+          title: "Acessibilidade",
           description:
-            "Pay attention to the user's reduced motion preferences and either make the animations less prominent or remove them altogether.",
+            "Esteja atento às preferências do usuário em relação a movimentos reduzidos e adapte as animações para serem menos chamativas ou remova-as completamente, se necessário.",
         },
       },
     },
     "df-iconography": {
-      title: "Iconography",
+      title: "Iconografia",
       description:
-        "Icons are symbols that represent functionality or content. They’re especially recognizable and helpful in user interfaces since their meaning can be understood at a glance. Though they can be used just for decoration, their full potential can be realized when they’re used meaningfully and consistently.",
+        "Ícones são símbolos que representam funcionalidades ou conteúdos. Eles são especialmente reconhecíveis e úteis em interfaces de usuário, pois seu significado pode ser compreendido rapidamente. Embora possam ser usados apenas para decoração, seu potencial completo pode ser percebido quando são utilizados de forma significativa e consistente.",
       checklist: {
         "df-iconography-a11y": {
-          title: "Accessibility",
+          title: "Acessibilidade",
           description:
-            "For icons that convey a meaning or serve a function, offer a default accessible name that expresses that same meaning or function. Screen readers and other assistive technologies may use this name to orient the user about the interface. For purely decorative icons, a name is not required. If your design system exports front-end code, ensure that the icon name is included, for example, using an aria-label.",
+            "Para ícones que transmitem um significado ou têm uma função específica, ofereça um nome acessível padrão que expresse esse mesmo significado ou função. Leitores de tela e outras tecnologias assistivas podem usar esse nome para orientar o usuário sobre a interface. Para ícones puramente decorativos, um nome não é necessário. Se o seu sistema de design exporta código front-end, certifique-se de incluir o nome do ícone, por exemplo, usando o atributo aria-label.",
         },
         "df-iconography-style": {
-          title: "Style",
+          title: "Estilo",
           description:
-            "Make sure that your icon family makes visual sense as a whole. Picking an outlined or filled style and sticking with it will lead to better visual consistency and predictability.",
+            "Certifique-se de que a sua família de ícones tenha uma coesão visual. Escolher um estilo contornado ou preenchido e mantê-lo em todo o produto resultará em uma melhor consistência visual e previsibilidade.",
         },
         "df-iconography-naming": {
-          title: "Naming",
+          title: "Nomenclatura",
           description:
-            "Name your icons based on their communicative purpose rather than how they look. For instance, a triangular media player plays button icon should be named 'play,' not 'triangle.' You can still add related keywords to improve discoverability.",
+            "Atribua nomes aos seus ícones com base em seu propósito comunicativo, em vez de sua aparência. Por exemplo, um ícone de botão de reprodução em formato triangular em um player de mídia deve ser nomeado como 'play' e não como 'triângulo'. Você ainda pode adicionar palavras-chave relacionadas para melhorar a facilidade de descoberta.",
         },
         "df-iconography-grid": {
-          title: "Relation with grid",
+          title: "Relação com o grid",
           description:
-            "Draw your icons in a bounding box that plays well with your grid. This makes for a better pairing with other UI elements. A good example would be icons with bounding boxes paired with text.",
+            "Crie seus ícones dentro de uma caixa delimitadora que esteja alinhada com seu grid. Isso proporcionará uma melhor harmonia com os outros elementos da interface. Um bom exemplo disso é o uso de ícones com caixas delimitadoras combinados com texto.",
         },
         "df-iconography-keywords": {
-          title: "Keywords",
+          title: "Palavras-chave",
           description:
-            "Adding keywords will improve the discoverability of each icon and provide a better user experience for anyone using your system.",
+            "A adição de palavras-chave melhorará a capacidade de descoberta de cada ícone e proporcionará uma melhor experiência do usuário para quem estiver usando seu sistema.",
         },
         "df-iconography-reserved": {
-          title: "Reserved icons",
+          title: "Ícones reservados",
           description:
-            "Reserving icons representing common actions will prevent their use in any other context. System icons for navigation or adding and deleting are good examples. This leads to a more intuitive user experience.",
+            "A reserva de ícones que representam ações comuns evita o uso deles em qualquer outro contexto. Ícones do sistema de navegação, adição e exclusão são bons exemplos. Isso resulta em uma experiência do usuário mais intuitiva.",
         },
         "df-iconography-guidelines": {
-          title: "Guidelines",
+          title: "Diretrizes",
           description:
-            "Provide guidelines on how and when to use icons, what to keep in mind when working with them, and how not to use them.",
+            "Forneça diretrizes sobre como e quando usar ícones, o que ter em mente ao trabalhar com eles e como não utilizá-los.",
         },
       },
     },

--- a/src/translations/pt/designLanguage.js
+++ b/src/translations/pt/designLanguage.js
@@ -1,70 +1,69 @@
 export default {
-  title: "Design language",
+  title: "Linguagem de design",
   description:
-    "Like any language, a design language is a methodical way of communicating with your audience through your approach to product design. It’s the cornerstone of consistent customer experiences.",
-
+    "Assim como qualquer linguagem, uma linguagem de design é uma metodologia de comunicação com os usuários por meio de teorias e termos do design de produto. É a base que proporcionará consistência às suas experiências.",
   sections: {
     "dl-brand": {
-      title: "Brand",
+      title: "Marca",
       description:
-        "Brand drives every single decision you make when building new products or features. A good brand is much more than a name and a logo. It’s the values that define your unique identity and what makes you stand out from others.",
+        "A marca orienta cada decisão que você toma ao criar novos produtos ou funcionalidades. Uma boa marca é muito mais do que um nome e um logotipo. São os valores que definem sua identidade única e o que faz você se destacar dos outros.",
       checklist: {
         "dl-brand-vision": {
-          title: "Vision",
+          title: "Visão",
           description:
-            "Why you exist, what your values are, and how they’ll help guide the future of your product.",
+            "Por que você existe, quais são os seus valores e como eles ajudarão a guiar o futuro do seu produto.",
         },
         "dl-brand-principles": {
-          title: "Design principles",
+          title: "Princípios de design",
           description:
-            "The considerations that guide the basis of your practice. They outline how you approach design philosophically and help with everyday decisions.",
+            "As considerações que orientam a base da sua prática. Eles delineiam como você aborda o design filosóficamente e auxiliam nas decisões cotidianas.",
         },
         "dl-brand-tone": {
-          title: "Tone of voice",
+          title: "Tom de voz",
           description:
-            "A clear tone of voice defines how you speak to your audience at every moment of their journey, helping them get wherever they want to go.",
+            "Um tom de voz claro define como você fala com seu público em cada momento da sua jornada, ajudando-os a chegar onde querem.",
         },
         "dl-brand-terminology": {
-          title: "Terminology",
+          title: "Terminologia",
           description:
-            "Create the standard terms and phrases that need to be kept the same throughout the user experience, speeding up the design process and unifying your voice.",
+            "Crie termos e frases padronizados que devem ser mantidos consistentes em toda a experiência do usuário, agilizando o processo de design e unificando sua linguagem.",
         },
         "dl-brand-assets": {
-          title: "Brand assets",
+          title: "Elementos da marca",
           description:
-            "Using a consistent set of brand assets aligns the user experience across your product and marketing campaigns. These assets include your logo, fonts, icons, illustrations, etc.",
+            "O uso de um conjunto consistente de elementos da marca unifica a experiência do usuário em todos os seus produtos e campanhas de marketing. Esses elementos englobam seu logotipo, fontes, ícones, ilustrações, etc.",
         },
       },
     },
     "dl-guidelines": {
-      title: "Guidelines",
+      title: "Diretrizes",
       description:
-        "Understanding how to approach common UX patterns will allow your organization to establish a consistent approach and user experience on any platform.",
+        "Entender como abordar padrões comuns de UX permitirá que sua organização estabeleça abordagens e experiências consistentes em qualquer plataforma.",
       checklist: {
         "dl-guidelines-a11y": {
-          title: "Accessibility",
+          title: "Acessibilidade",
           description:
-            "Guidelines for how you approach accessibility and how you leverage color, hierarchy, and assistive technologies to help your users.",
+            "Diretrizes sobre como abordar a acessibilidade e como utilizar cor, hierarquia e tecnologias assistivas para ajudar seus usuários.",
         },
         "dl-guidelines-writing": {
-          title: "Writing guidelines",
+          title: "Diretrizes de escrita",
           description:
-            "Every consistent experience needs watertight writing. Laying down the foundations for your house style early keeps everything in line with consistent grammar, style choices, and action-oriented language to help your design.",
+            "Toda experiência consistente requer uma escrita clara e precisa. Portanto, estabelecer bases sólidas desde o início auxilia na manutenção de um estilo e gramática consistentes, orientando as ações do usuário e aprimorando o design como um todo.",
         },
         "dl-guidelines-microcopy": {
-          title: "Microcopy guidelines",
+          title: "Diretrizes de microcopy",
           description:
-            "The standard way to write for the components in your design system. These take platform conventions and best practices for writing all into consideration.",
+            "A abordagem padrão de escrita para os componentes em seu design system, levando em consideração as convenções da plataforma e as melhores práticas de escrita.",
         },
         "dl-guidelines-terminology": {
-          title: "Terminology",
+          title: "Terminologia",
           description:
-            "Create the standard terms and phrases that need to be kept the same throughout the user experience, speeding up the design process and unifying your voice.",
+            "Crie termos e frases padronizados que devem ser mantidos consistentes em toda a experiência do usuário, agilizando o processo de design e unificando sua linguagem.",
         },
         "dl-guidelines-i18n": {
-          title: "Internationalisation",
+          title: "Internacionalização",
           description:
-            "Define standards for handling content translated into various languages supported by the product. It includes handling translation edge cases and content bi-directionality.",
+            "Defina padrões para lidar com o conteúdo traduzido em diferentes idiomas suportados pelo produto. Isso inclui lidar com casos especiais de tradução e com a bidirecionalidade do conteúdo.",
         },
       },
     },

--- a/src/translations/pt/maintenance.js
+++ b/src/translations/pt/maintenance.js
@@ -1,180 +1,179 @@
 export default {
-  title: "Maintenance",
+  title: "Manutenção",
   description:
-    "Design systems are no different than any other project your team might take on. In order to successfully build and maintain one, you need a clear strategy that’s well executed daily, and you‘ll need to create opportunities for your colleagues to give feedback to help share your design system together.",
-
+    "Design systems não são diferentes de qualquer outro projeto que sua equipe possa assumir. Para construir e manter um com sucesso, é necessário ter uma estratégia clara que seja bem executada diariamente, além de criar oportunidades para que seus colegas possam fornecer feedback e colaborar no desenvolvimento do design system.",
   sections: {
     "m-documentation": {
-      title: "Documentation",
+      title: "Documentação",
       description:
-        "Documentation resources are a core part of any design system as it saves time and effort for the team and everyone using the design system. It allows people to learn the ropes and find answers to the most commonly asked questions without contacting the team.",
+        "Documentação é uma parte fundamental de qualquer design system, pois economiza tempo e esforço da equipe e de todos que utilizam o sistema.  Isso possibilita que as pessoas aprendam os detalhes e encontrem respostas para as perguntas mais frequentes sem precisar entrar em contato direto com a equipe",
       checklist: {
         "m-documentation-principles": {
-          title: "Design system principles",
+          title: "Princípios do design system",
           description:
-            "List your core principles when building a design system to let designers and developers know your values and which are the main factors for the decision-making in your team.",
+            "Liste seus princípios fundamentais ao construir um design system, a fim de comunicar aos designers e desenvolvedores quais são seus valores e quais são os principais fatores considerados em sua equipe para tomada de decisões.",
         },
         "m-documentation-start": {
-          title: "Getting started",
+          title: "Primeiros passos",
           description:
-            "Guide others through the first steps of setting up and using your design system, which can help them build their first feature or product without contacting you directly.",
+            "Auxilie os outros nos primeiros passos de configuração e uso do seu design system, o que permitirá que eles possam desenvolver suas primeiras funcionalidades ou produtos sem precisar contatar você diretamente.",
         },
         "m-documentation-design": {
-          title: "Design best practices",
+          title: "Melhores práticas de design",
           description:
-            "Share tips on how to design products using the design system in a scalable way, avoid common pitfalls and use your design tool to its max potential.",
+            "Compartilhe dicas sobre como projetar produtos de forma escalável utilizando o design system, evitando armadilhas comuns e como aproveitar ao máximo o potencial da sua ferramenta de design.",
         },
         "m-documentation-dev": {
-          title: "Development best practices",
+          title: "Melhores práticas de desenvolvimento",
           description:
-            "Share tips on developing products using the design system, the recommended technical dependencies, and avoiding common pitfalls.",
+            "Compartilhe dicas sobre o desenvolvimento de produtos utilizando o design system, as dependências técnicas recomendadas e como evitar armadilhas comuns.",
         },
         "m-documentation-anatomy": {
-          title: "Component anatomy",
+          title: "Anatomia do componente",
           description:
-            "Provide an overview of the components' design anatomy to help everyone understand the limitations of the component layout and which parts of it are customizable.",
+            "Forneça uma visão geral da anatomia de design dos componentes para auxiliar na compreensão das limitações do layout do componente e quais partes dele podem ser personalizadas.",
         },
         "m-documentation-props": {
-          title: "Component properties",
+          title: "Propriedades do componente",
           description:
-            "Document properties your components support in both design and code. We recommend aligning most of them across platforms for a smoother design handoff process.",
+            "Documente as propriedades suportadas pelos seus componentes tanto no design quanto no código. Recomendamos alinhar a maioria delas entre as plataformas para facilitar o processo de transição do design.",
         },
         "m-documentation-composition": {
-          title: "Component composition examples",
+          title: "Exemplos de composição do componente",
           description:
-            "When building low-level components supporting slots for inserting other content – provide examples of how to use them to create more advanced compositions.",
+            "Ao construir componentes de baixo nível que possuam slots para inserção de outros conteúdos, forneça exemplos que demonstrem como utilizá-los para criar composições mais avançadas.",
         },
         "m-documentation-sandbox": {
-          title: "Sandbox product example",
+          title: "Ambiente de teste do produto",
           description:
-            "If you don’t have a way to test your components in the product yourself, you can build a simple application that simulates actual product layouts to test how your components behave in the wild and try out new design system features before releasing them.",
+            "Se você não tem uma forma de testar seus componentes no próprio produto, você pode construir uma aplicação simples que simula layouts reais do produto. Assim, você poderá avaliar o comportamento dos seus componentes e experimentar novas funcionalidades do sistema de design antes de lançá-las.",
         },
         "m-documentation-env": {
-          title: "Browser / OS support",
+          title: "Compatibilidade com navegadores e sistemas operacionais",
           description:
-            "Define the level of support you provide for various operating systems and browsers, and make sure you align with the product on this topic.",
+            "Estabeleça o nível de suporte que você oferece para diferentes sistemas operacionais e navegadores, e assegure-se de estar alinhado com o produto nesse aspecto.",
         },
         "m-documentation-release": {
-          title: "Release cycle",
+          title: "Ciclo de lançamento",
           description:
-            "Establish and document a predictable release cycle for the major versions that include breaking changes. This way, product teams can plan the migrations on their side.",
+            "Estabeleça e documente um ciclo de lançamento previsível para as versões principais que envolvam alterações significativas. Isso permitirá que as equipes de produto planejem as migrações em seu próprio ambiente de forma adequada.",
         },
       },
     },
     "m-local": {
-      title: "Local libraries",
+      title: "Bibliotecas locais",
       description:
-        "The scope of the design system is usually to build the core repeating patterns to increase the velocity of product teams. That means you won't implement all UI elements yourself. Product teams will still build local components using the design system to solve their specific scenarios.",
+        "O objetivo do design system é, geralmente, construir os padrões centrais e recorrentes para acelerar as equipes de produto. Isso significa que você não precisa implementar todos os elementos de interface por conta própria. As equipes de produto ainda criarão componentes locais utilizando o sistema de design para resolver seus cenários específicos.",
       checklist: {
         "m-local-when": {
-          title: "When to build",
+          title: "Quando construir",
           description:
-            "Share your expectations on when product teams should build custom components instead of requesting a new feature in the design system or using an existing component.",
+            "Compartilhe suas expectativas sobre quando as equipes de produto devem construir componentes personalizados em vez de solicitar um novo recurso no design system ou usar um componente existente.",
         },
         "m-local-types": {
-          title: "Horizontal and vertical libraries",
+          title: "Bibliotecas horizontais e verticais",
           description:
-            "Outline the difference between the horizontal libraries used across multiple products and vertical libraries only used by the team building it.",
+            "Explicite a distinção entre as bibliotecas horizontais, que são empregadas em diversos produtos, e as bibliotecas verticais, que são usadas apenas pela equipe que as constrói.",
         },
         "m-local-expectations": {
-          title: "Library expectations",
+          title: "Expectativas em relação à biblioteca",
           description:
-            "Document the minimum set of requirements for shipping a local library. Describe your expectations on the library quality, documentation, and maintenance.",
+            "Documente o conjunto mínimo de requisitos para lançar uma biblioteca local. Descreva suas expectativas em relação à qualidade, documentação e manutenção da biblioteca.",
         },
         "m-local-release": {
-          title: "Release cycle alignment",
+          title: "Alinhamento do ciclo de lançamento",
           description:
-            "Ensure that local libraries are in sync with the design system release cycle. They should support your newly published major releases of the system to avoid blocking the product from updating.",
+            "Assegure que as bibliotecas locais estejam alinhadas com o ciclo de lançamento do design system. Elas devem ser compatíveis com as novas versões principais recentemente publicadas do sistema, evitando assim impedimentos na atualização do produto.",
         },
       },
     },
     "m-process": {
-      title: "Team processes",
+      title: "Processos da equipe",
       description:
-        "All teams that have successfully scaled their design system did this by establishing robust processes for working with their stakeholders and the community. As you keep developing the system, they will save you endless hours and let you avoid answering the same questions repeatedly.",
+        "Equipes que alcançaram sucesso na escalabilidade de seus sistemas de design o fizeram estabelecendo processos sólidos para trabalhar com seus stakeholders e a comunidade. À medida que você continua desenvolvendo o sistema, esses processos pouparão inúmeras horas e evitarão que você precise responder repetidamente às mesmas perguntas.",
       checklist: {
         "m-process-log": {
-          title: "Decision-making log",
+          title: "Registro de tomada de decisões",
           description:
-            "For the topics you have to handle repeatedly – make logs on how you make those decisions. You won’t miss any contextual requirements and will avoid having additional alignment meetings.",
+            "Para os tópicos que você precisa lidar repetidamente, faça registros sobre como você toma essas decisões. Isso permitirá que você não perca nenhum requisito contextual e evitará a necessidade de reuniões adicionais para alinhamento.",
         },
         "m-process-roadmap": {
-          title: "Roadmap",
+          title: "Cronograma",
           description:
-            "Try planning your long-term work and allocating only a part of your time for community support. This will help you evolve the system over time instead of only focusing on smaller bug fixes and feature requests.",
+            "Tente planejar seu trabalho a longo prazo e destinar apenas uma parte do seu tempo para o suporte à comunidade. Isso ajudará você a evoluir o sistema ao longo do tempo, em vez de se concentrar apenas em correções de pequenos bugs e solicitações de novas funcionalidades.",
         },
         "m-process-stakeholder": {
-          title: "Stakeholder mapping",
+          title: "Mapeamento dos stakeholders",
           description:
-            "List out the main stakeholders across all products you’re supporting. Those could be people working in the development and design but also don’t miss the people leadership who can help you grow the adoption.",
+            "Faça uma lista dos principais stakeholders envolvidos em todos os produtos que você está apoiando. Isso inclui pessoas que trabalham no desenvolvimento e design, mas também não se esqueça dos líderes que podem ajudar a impulsionar a adoção do sistema.",
         },
         "m-process-analytics": {
-          title: "Analytics",
+          title: "Análises",
           description:
-            "Define a way to track the usage and the value of the libraries and tooling you provide. You can start with easy-to-set-up metrics, like analytics for your documentation website, feedback surveys, or components usage analytics in your design tool.",
+            "Estabeleça um método para acompanhar o uso e o valor das bibliotecas e ferramentas que você disponibiliza. Você pode começar com métricas fáceis de configurar, como análises do site de documentação, pesquisas de feedback e análises do uso dos componentes na sua ferramenta de design.",
         },
         "m-process-shifts": {
-          title: 'Ongoing support "shifts"',
+          title: "Rotação contínua de suporte",
           description:
-            "If multiple people work on the same platform, distribute and plan the community support work for them. That will let team members focus on the planned work instead of being distracted by the requests and questions.",
+            "Se várias pessoas trabalham na mesma plataforma, distribua e planeje as responsabilidades de suporte à comunidade entre elas. Isso permitirá que os membros da equipe se concentrem nas tarefas planejadas, evitando distrações com solicitações e perguntas.",
         },
         "m-process-sla": {
-          title: "SLA",
+          title: "SLA (Acordo de nível de serviço)",
           description:
-            "Define the timelines for how long it takes you to handle incoming requests and bug reports to help product teams understand if they should wait for your release or find a temporary workaround.",
+            "Defina prazos para o tempo de resposta às solicitações recebidas e aos relatórios de bugs, a fim de ajudar as equipes de produto a decidir se devem aguardar o lançamento oficial ou buscar uma solução temporária.",
         },
       },
       "m-community": {
-        title: "Community support",
+        title: "Suporte à comunidade",
         description:
-          "It’s crucial to help product designers and developers get more productive with the design system, fix the bugs they find in the products, and address their needs. To make sure you get that feedback – your goal is to make it easy and safe for everyone to share their findings.",
+          "É fundamental auxiliar os designers e desenvolvedores de produto a aumentarem sua produtividade com o sistema de design, solucionar os bugs encontrados nos produtos e atender às suas necessidades. Para garantir que você obtenha esse feedback, o seu objetivo é tornar fácil e seguro para todos compartilharem suas descobertas.",
         checklist: {
           "m-community-channels": {
-            title: "Support channels",
+            title: "Canais de suporte",
             description:
-              "Create support channels in the tools you use for communication. It’s a good idea to separate them by the platform to make it comfortable for everyone to share platform-specific details of their issues.",
+              "Crie canais de suporte nas ferramentas que você utiliza para comunicação. É uma boa ideia separá-los por plataforma, para que todos possam compartilhar de maneira confortável os detalhes específicos da plataforma relacionados aos seus problemas.",
           },
           "m-community-template": {
             title: "Templates",
             description:
-              "Prepare templates for creating feature requests and bug reports. Use them to ask for reproduction links, design proposals, and other contextual information you need to make decisions instead of manually looking for that information.",
+              "Elabore templates para criar solicitações de funcionalidade e relatórios de bugs. Utilize-os para solicitar links de reprodução, propostas de design e outras informações contextuais necessárias para tomar decisões, em vez de procurar manualmente por essas informações.",
           },
           "m-community-updates": {
-            title: "Regular updates",
+            title: "Atualizações regulares",
             description:
-              "You’re risking the adoption of the new features if you’re only focusing on the implementation but never talking about it with the community. Defining a cadence for your updates helps build a habit for product teams to come and check what’s new in the system and how they can leverage it.",
+              "Você está arriscando a adoção das novas funcionalidades se estiver apenas focado na implementação, sem nunca discuti-las com a comunidade. Estabelecer uma frequência para suas atualizações ajuda a criar o hábito das equipes de produto de conferir regularmente o que há de novo no sistema e como podem aproveitá-lo ao máximo.",
           },
           "m-community-slots": {
-            title: "Open hours",
+            title: "Horários de disponibilidade",
             description:
-              "There will be questions that can’t be resolved in a single ticket or chat. Keep a few bookable calendar slots for other teams to receive a consultation or discuss their feature implementation with your team.",
+              "Haverá perguntas que não podem ser resolvidas em um único ticket ou chat. Reserve alguns horários disponíveis em seu calendário para que outras equipes possam agendar consultas ou discutir a implementação de funcionalidades com a sua equipe.",
           },
         },
       },
       "m-contribution": {
-        title: "Contribution",
+        title: "Contribuição",
         description:
-          "Building design systems is a team game. Make sure to include product teams in the journey, help them contribute to the system and let them advocate for it across the company.",
+          "Construir design systems é um trabalho em equipe. Certifique-se de incluir as equipes de produto nessa jornada, auxiliando-as a contribuir para o sistema e permitindo que elas o defendam em toda a empresa.",
         checklist: {
           "m-contribution-rules": {
-            title: "House rules for the system",
+            title: "Regras da casa para o sistema",
             description:
-              "Explain how your design and development process works to the product teams. Design system teams usually move slower than product teams since there is more responsibility on making scalable decisions in the components affecting the whole product.",
+              "Explique às equipes de produto como funciona o seu processo de design e desenvolvimento. As equipes de design system geralmente trabalham em um ritmo mais lento do que as equipes de produto, pois há maior responsabilidade em tomar decisões escaláveis nos componentes que afetam o produto como um todo.",
           },
           "m-contribution-guidelines": {
-            title: "Contribution guidelines",
+            title: "Orientações de contribuição",
             description:
-              "Explain what contributors need to set up to prepare their design and development environment for adding and testing new features.",
+              "Explique o que os colaboradores precisam configurar para preparar seu ambiente de design e desenvolvimento para adicionar e testar novas funcionalidades.",
           },
           "m-contribution-template": {
-            title: "Feature proposal template",
+            title: "Template para proposta de nova funcionalidade",
             description:
-              "Prepare a standard template for initiating the work on a new feature. This template should ensure that proposed changes will be applied across all platforms and won’t break the existing component usage in the product.",
+              "Elabore um template padrão para iniciar o trabalho em uma nova funcionalidade. Esse modelo deve garantir que as alterações propostas sejam aplicadas em todas as plataformas e não comprometam a utilização atual dos componentes no produto.",
           },
           "m-contribution-engagement": {
-            title: "Engagment",
+            title: "Engajamento",
             description:
-              "Make sure to highlight and reward contributors' work when making announcements about the new features and help them get support from their managers when they contribute. ",
+              "Assegure-se de destacar e recompensar o trabalho dos colaboradores ao fazer anúncios sobre as novas funcionalidades e ajude-os a obter apoio de seus gerentes quando eles contribuírem.",
           },
         },
       },


### PR DESCRIPTION
This PR adds Portuguese translations for V2.
 
- Fixed text in `en/components.js`
- Fixed text in `en/maintenance.js`
- Kept the translations of these components the same as the English version, as it's the most commonly used, even in Portuguese:
   - Accordion
   - Avatar
   - Badge
   - Breadcrumbs
   - Card
   - Checkbox
   - Dropdown
   - Link
   - Modal
   - Radio
   - Select
   - Skeleton
   - Switch
   - Tabs
   - Toast
   - Tooltip
   